### PR TITLE
Add warning message for unset DISPLAY env

### DIFF
--- a/exegol/utils/GuiUtils.py
+++ b/exegol/utils/GuiUtils.py
@@ -62,6 +62,12 @@ class GuiUtils:
         if EnvInfo.isMacHost():
             # xquartz Mac mode
             return "host.docker.internal:0"
+
+        # Add ENV check is case of user don't have it, which will mess up GUI if fallback does not work
+        # @see https://github.com/ThePorgs/Exegol/issues/148
+        if os.getenv("DISPLAY") is None:
+            logger.warning("The DISPLAY environment variable is not set on your host. This can prevent GUI apps to start")
+
         # DISPLAY var is fetch from the current user environment. If it doesn't exist, using ':0'.
         return os.getenv('DISPLAY', ":0")
 


### PR DESCRIPTION
# Description

Tiny PR to send a warning message if DISPLAY environment variable is not set on host, which can prevents GUI commands to start

# Related issues

Fixes #148 
