### PR TITLE
Fix inconsistency to enable shell logging

### DIFF
--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -272,9 +272,9 @@ class ContainerConfig:
 
         # Shell logging config
         if self.__shell_logging:
-            if Confirm("Do you want to [green]enable[/green] automatic [blue]shell logging[/blue]?", False):
+            if Confirm("Do you want to [orange3]disable[/orange3] automatic [blue]shell logging[/blue]?", False):
                 self.__disableShellLogging()
-        elif Confirm("Do you want to [orange3]disable[/orange3] automatic [blue]shell logging[/blue]?", False):
+        elif Confirm("Do you want to [green]enable[/green] automatic [blue]shell logging[/blue]?", False):
             self.enableShellLogging()
         # Command builder info
         if self.__shell_logging:


### PR DESCRIPTION

# Description

Before the change, at the question "Do you want to disable ..." we had to enter y to enable

