### PR TITLE
Exegol 4.2.2

### DIFF
--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class ConstantConfig:
     """Constant parameters information"""
     # Exegol Version
-    version: str = "4.2.2b1"
+    version: str = "4.2.2"
 
     # Exegol documentation link
     documentation: str = "https://exegol.rtfd.io/"

--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class ConstantConfig:
     """Constant parameters information"""
     # Exegol Version
-    version: str = "4.2.1"
+    version: str = "4.2.2b1"
 
     # Exegol documentation link
     documentation: str = "https://exegol.rtfd.io/"

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -74,7 +74,7 @@ class ExegolImage(SelectableInterface):
                 self.__is_remote = True
                 self.__setArch(MetaImages.parseArch(dockerhub_data))
                 self.__dl_size = self.__processSize(dockerhub_data.get("size", 0))
-            if meta_img:
+            if meta_img and meta_img.meta_id is not None:
                 self.__setDigest(meta_img.meta_id)
                 self.__setLatestRemoteId(meta_img.meta_id)  # Meta id is always the latest one
         logger.debug(f"└── {self.__name}\t→ ({self.getType()}) {self.__digest}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docker~=6.0.0
-requests>=2.28.0
+requests~=2.28.2
 rich~=13.3.0
 GitPython~=3.1.29
 PyYAML>=6.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     ],
     install_requires=[
         'docker~=6.0.0',
-        'requests',
+        'requests~=2.28.2',
         'rich~=13.3.0',
         'PyYAML',
         'GitPython',

--- a/tests/test_exegol.py
+++ b/tests/test_exegol.py
@@ -2,4 +2,4 @@ from exegol import __version__
 
 
 def test_version():
-    assert __version__ == '4.2.1'
+    assert __version__ == '4.2.2'


### PR DESCRIPTION
# Description

New minor version with some minor bug fix

# Related issues

- Fix typo in interactive configuration with #155 
- Constraint requests to 2.28.x as a temporary patch while the 2.29.x have some incompatibility

