### PR TITLE
 Exegol 4.2.3

### DIFF
--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class ConstantConfig:
     """Constant parameters information"""
     # Exegol Version
-    version: str = "4.2.3b1"
+    version: str = "4.2.3"
 
     # Exegol documentation link
     documentation: str = "https://exegol.rtfd.io/"

--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class ConstantConfig:
     """Constant parameters information"""
     # Exegol Version
-    version: str = "4.2.2"
+    version: str = "4.2.3b1"
 
     # Exegol documentation link
     documentation: str = "https://exegol.rtfd.io/"

--- a/exegol/config/EnvInfo.py
+++ b/exegol/config/EnvInfo.py
@@ -3,6 +3,7 @@ import platform
 import re
 import shutil
 import subprocess
+from enum import Enum
 from typing import Optional, Any, List
 
 from exegol.config.ConstantConfig import ConstantConfig
@@ -13,13 +14,13 @@ class EnvInfo:
     """Class to identify the environment in which exegol runs to adapt
     the configurations, processes and messages for the user"""
 
-    class HostOs:
+    class HostOs(Enum):
         """Dictionary class for static OS Name"""
         WINDOWS = "Windows"
         LINUX = "Linux"
         MAC = "Mac"
 
-    class DockerEngine:
+    class DockerEngine(Enum):
         """Dictionary class for static Docker engine name"""
         WLS2 = "WSL2"
         HYPERV = "Hyper-V"
@@ -36,8 +37,8 @@ class EnvInfo:
     __is_docker_desktop: bool = False
     __windows_release: Optional[str] = None
     # Host OS
-    __docker_host_os: Optional[str] = None
-    __docker_engine: Optional[str] = None
+    __docker_host_os: Optional[HostOs] = None
+    __docker_engine: Optional[DockerEngine] = None
     # Docker desktop cache config
     __docker_desktop_resource_config = None
     # Architecture
@@ -99,7 +100,7 @@ class EnvInfo:
             cls.__docker_host_os = cls.HostOs.LINUX
 
     @classmethod
-    def getHostOs(cls) -> str:
+    def getHostOs(cls) -> HostOs:
         """Return Host OS
         Can be 'Windows', 'Mac' or 'Linux'"""
         # initData must be called from DockerUtils on client initialisation
@@ -154,9 +155,9 @@ class EnvInfo:
         return cls.__docker_engine == cls.DockerEngine.ORBSTACK
 
     @classmethod
-    def getDockerEngine(cls) -> str:
+    def getDockerEngine(cls) -> DockerEngine:
         """Return Docker engine type.
-        Can be 'kernel', 'mac', 'wsl2' or 'hyper-v'"""
+        Can be any of EnvInfo.DockerEngine"""
         # initData must be called from DockerUtils on client initialisation
         assert cls.__docker_engine is not None
         return cls.__docker_engine

--- a/exegol/manager/ExegolManager.py
+++ b/exegol/manager/ExegolManager.py
@@ -219,7 +219,7 @@ class ExegolManager:
         if EnvInfo.isWindowsHost():
             logger.debug(f"Windows release: {EnvInfo.getWindowsRelease()}")
             logger.debug(f"Python environment: {EnvInfo.current_platform}")
-            logger.debug(f"Docker engine: {EnvInfo.getDockerEngine().upper()}")
+            logger.debug(f"Docker engine: {str(EnvInfo.getDockerEngine()).upper()}")
         logger.debug(f"Docker desktop: {boolFormatter(EnvInfo.isDockerDesktop())}")
         logger.debug(f"Shell type: {EnvInfo.getShellType()}")
         if not UpdateManager.isUpdateTag() and UserConfig().auto_check_updates:

--- a/exegol/manager/ExegolManager.py
+++ b/exegol/manager/ExegolManager.py
@@ -226,7 +226,7 @@ class ExegolManager:
             UpdateManager.checkForWrapperUpdate()
         if UpdateManager.isUpdateTag():
             logger.empty_line()
-            if Confirm("An [green]Exegol[/green] update is [orange3]available[/orange3], do you want to update ?", default=True):
+            if Confirm(f"An [green]Exegol[/green] update is [orange3]available[/orange3] ({UpdateManager.display_current_version()} -> {UpdateManager.display_latest_version()}), do you want to update ?", default=True):
                 UpdateManager.updateWrapper()
         else:
             logger.empty_line(log_level=logging.DEBUG)

--- a/exegol/manager/UpdateManager.py
+++ b/exegol/manager/UpdateManager.py
@@ -264,7 +264,7 @@ class UpdateManager:
             module = ExegolModules().getWrapperGit(fast_load=True)
             if module.isAvailable:
                 commit_version = f" [bright_black]\[{str(module.get_current_commit())[:8]}][/bright_black]"
-        return f"[blue]v{ConstantConfig.version}[blue]{commit_version}"
+        return f"[blue]v{ConstantConfig.version}[/blue]{commit_version}"
 
     @classmethod
     def __tagUpdateAvailable(cls, latest_version, current_version=None):
@@ -285,6 +285,10 @@ class UpdateManager:
             if wrapper_data.current_version != current_version:
                 cls.__untagUpdateAvailable(current_version)
             return False
+
+    @classmethod
+    def display_latest_version(cls) -> str:
+        return f"[blue]v{DataCache().get_wrapper_data().last_version}[/blue]"
 
     @classmethod
     def __untagUpdateAvailable(cls, current_version: Optional[str] = None):

--- a/exegol/utils/GuiUtils.py
+++ b/exegol/utils/GuiUtils.py
@@ -175,7 +175,7 @@ class GuiUtils:
             logger.error("WSL is [orange3]not available[/orange3] on your system. GUI is not supported.")
             return False
         # Only WSL2 support WSLg
-        if EnvInfo.getDockerEngine() != "wsl2":
+        if EnvInfo.getDockerEngine() != EnvInfo.DockerEngine.WLS2:
             logger.error("Docker must be run with [orange3]WSL2[/orange3] engine in order to support GUI applications.")
             return False
         logger.debug("WSL is [green]available[/green] and docker is using WSL2")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-docker~=6.0.0
-requests~=2.28.2
+docker~=6.1.2
+requests~=2.30.0
 rich~=13.3.0
 GitPython~=3.1.29
 PyYAML>=6.0
-argcomplete~=2.1.1
+argcomplete~=3.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docker~=6.1.2
-requests~=2.30.0
+requests>=2.30.0
 rich~=13.3.0
 GitPython~=3.1.29
 PyYAML>=6.0

--- a/setup.py
+++ b/setup.py
@@ -49,12 +49,12 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'docker~=6.0.0',
-        'requests~=2.28.2',
+        'docker~=6.1.2',
+        'requests>=2.30.0',
         'rich~=13.3.0',
         'PyYAML',
         'GitPython',
-        'argcomplete~=2.1.1'
+        'argcomplete~=3.0.8'
     ],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,

--- a/tests/test_exegol.py
+++ b/tests/test_exegol.py
@@ -2,4 +2,4 @@ from exegol import __version__
 
 
 def test_version():
-    assert __version__ == '4.2.2'
+    assert __version__ == '4.2.3'


### PR DESCRIPTION
# Description

New minor version with some minor bug fix.
Adding support for Python 3.11 (through requirements upgrade). 

> For source installation remember to run `pip3 install --upgrade -r requirements.txt`

# Related updates

- Fix GUI test for WSL2 engine
- Fix docker & requests > 2.29.x
- Add Python 3.11 support
- Minor update for the upgrade message
