### PR TITLE
feat: [#173] add base instal shell script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Environment status
+if [ -r /etc/os-release ]; then
+	. /etc/os-release
+fi
+
+check_dependencies() {
+    while [ $# -gt 0 ]; do
+        command -v "$1" > /dev/null 2>&1 || (echo "Missing $1" && exit 1)
+    shift
+    done
+
+}
+
+check_docker_right() {
+    docker ps 1>/dev/null || (echo "Docker execution error for ${USER}" && exit 1)
+}
+
+cloning_repos() {
+    git clone "https://github.com/ThePorgs/Exegol"
+}
+
+install_python_requirements() {
+    if [ $ID = "debian" ] && [ $VERSION_ID -ge "12" ]; then
+    python3 -m pip install --requirement "Exegol/requirements.txt" --break-system-packages
+    else
+    python3 -m pip install --requirement "Exegol/requirements.txt"
+    fi
+}
+
+add_exegol_path() {
+    cd Exegol && sudo ln -s "$(pwd)/exegol.py" "/usr/local/bin/exegol"
+}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -v|--verbose)
+            set -x
+        ;;
+    esac
+shift
+done
+
+check_dependencies "git" "python3" "docker" "sudo"
+check_docker_right
+cloning_repos
+install_python_requirements
+add_exegol_path
+
+### Run Exegol install 
+exegol install


### PR DESCRIPTION
Hi,

I have made a simply script for install Exegol wrapper like "curl -s https://github.com/TheProgs/Exegol/install.sh | sh"

It's work for GNU/Linux Debian distro but i continue for Fedora / Alpine and Debian-Like (ex: Ubuntu)
It is created in shell script and not in bash because the shell is available by default on all GNU/Linux systems.

a debug mode is available with the -v|--verbose argument

Please note:
In its current state, it is not completely immutable and is not insensitive to breakage.
For example, if a package is not installed, the script will not install it but will say which package is missing. Similarly, it cannot be restarted cleanly in the event of a problem. 


