### PR TITLE
Remove Orbstack /etc/ configuration

### DIFF
--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -785,10 +785,6 @@ class ContainerConfig:
             if EnvInfo.isMacHost():
                 # Add support for /etc
                 path_match = str(path)
-                if path_match.startswith("/etc/"):
-                    if EnvInfo.isOrbstack():
-                        raise CancelOperation(f"Orbstack doesn't support sharing /etc files with the container")
-                    path_match = path_match.replace("/etc/", "/private/etc/")
                 if EnvInfo.isDockerDesktop():
                     match = False
                     # Find a match


### PR DESCRIPTION
# Description

The latest version of OrbStack can now mount /etc/localtime. So this configuration is not needed anymore.

# Related issues

No related issue.

# Point of attention

I tested and everything seems to work fine but I'm not sure.
