### PR TITLE
removing special chars from random root password

### DIFF
--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -756,7 +756,7 @@ class ContainerConfig:
         """
         Generate a new random password.
         """
-        charset = string.ascii_letters + string.digits + string.punctuation.replace("'", "")
+        charset = string.ascii_letters + string.digits
         return ''.join(random.choice(charset) for i in range(length))
 
     @staticmethod


### PR DESCRIPTION
An issue existed where the root password would sometimes be generated with special chars that would mess with the password reset command, effectively not setting the password correctly