### PR TITLE
Show estimated images uncompressed size

### DIFF
--- a/exegol/console/TUI.py
+++ b/exegol/console/TUI.py
@@ -213,9 +213,9 @@ class ExegolTUI:
                                   image.getRealSize(), image.getBuildDate(), image.getStatus())
             else:
                 if safe_key:
-                    table.add_row(str(i + 1), image.getDisplayName(), image.getSize(), image.getStatus())
+                    table.add_row(str(i + 1), image.getDisplayName(), image.getRealSize(), image.getStatus())
                 else:
-                    table.add_row(image.getDisplayName(), image.getSize(), image.getStatus())
+                    table.add_row(image.getDisplayName(), image.getRealSize(), image.getStatus())
 
     @staticmethod
     def __buildContainerTable(table: Table, data: Sequence[ExegolContainer], safe_key: bool = False):

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -569,11 +569,11 @@ class ExegolImage(SelectableInterface):
         self.__disk_size = self.__processSize(value)
 
     def getRealSize(self) -> str:
-        """On-Disk size getter"""
+        """Image size getter. If the image is installed, return the on-disk size, otherwise return the remote size"""
         return self.__disk_size if self.__is_install else f"[bright_black]~{self.__remote_est_size}[/bright_black]"
 
     def getRealSizeRaw(self) -> str:
-        """On-Disk size getter"""
+        """Image size getter without color. If the image is installed, return the on-disk size, otherwise return the remote size"""
         return self.__disk_size if self.__is_install else self.__remote_est_size
 
     def getDownloadSize(self) -> str:

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -582,10 +582,6 @@ class ExegolImage(SelectableInterface):
             return "local"
         return self.__dl_size
 
-    def getSize(self) -> str:
-        """Image size getter. If the image is installed, return the on-disk size, otherwise return the remote size"""
-        return self.__disk_size if self.__is_install else f"[bright_black]~{self.__remote_est_size}[/bright_black]"
-
     def getEntrypointConfig(self) -> Optional[Union[str, List[str]]]:
         """Image's entrypoint configuration getter.
         Exegol images before 3.x.x don't have any entrypoint set (because /.exegol/entrypoint.sh don't exist yet. In this case, this getter will return None."""

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -572,6 +572,10 @@ class ExegolImage(SelectableInterface):
         """On-Disk size getter"""
         return self.__disk_size if self.__is_install else f"[bright_black]~{self.__remote_est_size}[/bright_black]"
 
+    def getRealSizeRaw(self) -> str:
+        """On-Disk size getter"""
+        return self.__disk_size if self.__is_install else self.__remote_est_size
+
     def getDownloadSize(self) -> str:
         """Remote size getter"""
         if not self.__is_remote:

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from datetime import datetime
 from typing import List, Optional, Union, cast
 
@@ -446,7 +447,8 @@ class DockerUtils:
         logger.info(f"{'Installing' if install_mode else 'Updating'} exegol image : {image.getName()}")
         name = image.updateCheck()
         if name is not None:
-            logger.info(f"Starting download. Please wait, this might be (very) long.")
+            logger.raw(f"[bold blue][*][/bold blue] Pulling compressed image, starting a [cyan1]{image.getDownloadSize()}[/cyan1] download :satellite:{os.linesep}", level=logging.INFO, markup=True, emoji=True)
+            logger.raw(f"[bold blue][*][/bold blue] Once downloaded and uncompressed, the image will take [cyan1]~{image.getRealSizeRaw()}[/cyan1] on disk :floppy_disk:{os.linesep}", level=logging.INFO, markup=True, emoji=True)
             logger.debug(f"Downloading {ConstantConfig.IMAGE_NAME}:{name} ({image.getArch()})")
             try:
                 ExegolTUI.downloadDockerLayer(

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -1,5 +1,4 @@
 import os
-import logging
 from datetime import datetime
 from typing import List, Optional, Union, cast
 

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -447,8 +447,8 @@ class DockerUtils:
         logger.info(f"{'Installing' if install_mode else 'Updating'} exegol image : {image.getName()}")
         name = image.updateCheck()
         if name is not None:
-            logger.raw(f"[bold blue][*][/bold blue] Pulling compressed image, starting a [cyan1]{image.getDownloadSize()}[/cyan1] download :satellite:{os.linesep}", level=logging.INFO, markup=True, emoji=True)
-            logger.raw(f"[bold blue][*][/bold blue] Once downloaded and uncompressed, the image will take [cyan1]~{image.getRealSizeRaw()}[/cyan1] on disk :floppy_disk:{os.linesep}", level=logging.INFO, markup=True, emoji=True)
+            logger.info(f"Pulling compressed image, starting a [cyan1]~{image.getDownloadSize()}[/cyan1] download :satellite:")
+            logger.info(f"Once downloaded and uncompressed, the image will take [cyan1]~{image.getRealSizeRaw()}[/cyan1] on disk :floppy_disk:")
             logger.debug(f"Downloading {ConstantConfig.IMAGE_NAME}:{name} ({image.getArch()})")
             try:
                 ExegolTUI.downloadDockerLayer(


### PR DESCRIPTION
Previously, the wrapper would show remote image compressed size when they were not installed.
This is because the real, uncompressed, size cannot be fetched through Dockerhub and because the compression factor is not publick knowledge.

I downloaded a few images and did the math
| Image  | Version | Arch | compressed (GB) | uncompressed (GB) | comp. rate | 
| ------- | ------- | ----- | ----------------- | --------------------- | ---------- |
| nightly | 15b188c0 | arm64 | 14.3 | 34.7 | 2.42 |
| web | 3.1.1 | arm64 | 6.5 | 15.1 | 2.32 |
| osint | 3.1.1 | arm64 | 3.2 | 8.2 | 2.56 |
| light | 3.1.1 | arm64 | 4.6 | 11.9 | 2.58 |
| full | 3.1.1 | arm64 | 13.9 | 33.9 |2.43  |

The comp. factor goes up to **x2.6**.
Taking this into account, I modified the wrapper to show that estimated size instead as it makes more sense for the end user to know how much room it'll take on disk. This replaces the "compressed download" size on the images list available through (for instance) `exegol info`.

![Image](https://github.com/ThePorgs/Development/assets/40902872/232fd452-b5c5-4690-b77e-f0ad3684753f)

When increasing verbosity, both  "compressed download" size and "real size on disk" are shown

![Image](https://github.com/ThePorgs/Development/assets/40902872/c1cb2383-d4ea-44cf-83ee-21d55125aef5)