### PR TITLE
Custom dockerfiles path for local builds

### DIFF
--- a/exegol/console/cli/ExegolCompleter.py
+++ b/exegol/console/cli/ExegolCompleter.py
@@ -1,6 +1,8 @@
 from argparse import Namespace
+from pathlib import Path
 from typing import Tuple
 
+from exegol.config.ConstantConfig import ConstantConfig
 from exegol.config.DataCache import DataCache
 from exegol.config.UserConfig import UserConfig
 from exegol.manager.UpdateManager import UpdateManager
@@ -58,7 +60,19 @@ def BuildProfileCompleter(prefix: str, parsed_args: Namespace, **kwargs) -> Tupl
     # The build profile completer must be trigger only when an image name have been set by user
     if parsed_args is not None and parsed_args.imagetag is None:
         return ()
-    data = list(UpdateManager.listBuildProfiles().keys())
+
+    # Default build path
+    build_path = ConstantConfig.build_context_path_obj
+    # Handle custom build path
+    if parsed_args is not None and parsed_args.build_path is not None:
+        custom_build_path = Path(parsed_args.build_path).expanduser().absolute()
+        # Check if we have a directory or a file to select the project directory
+        if not custom_build_path.is_dir():
+            custom_build_path = custom_build_path.parent
+        build_path = custom_build_path
+
+    # Find profile list
+    data = list(UpdateManager.listBuildProfiles(profiles_path=build_path).keys())
     for obj in data:
         if prefix and not obj.lower().startswith(prefix.lower()):
             data.remove(obj)

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -78,7 +78,6 @@ class Install(Command, ImageSelector):
         # Create container build arguments
         self.build_profile = Option("build_profile",
                                     metavar="BUILD_PROFILE",
-                                    choices=UpdateManager.listBuildProfiles().keys(),
                                     nargs="?",
                                     action="store",
                                     help="Select the build profile used to create a local image.",

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -4,6 +4,7 @@ from exegol.console.cli.actions.GenericParameters import *
 from exegol.manager.ExegolManager import ExegolManager
 from exegol.manager.UpdateManager import UpdateManager
 from exegol.utils.ExeLog import logger
+from exegol.config.ConstantConfig import ConstantConfig
 
 
 class Start(Command, ContainerCreation, ContainerSpawnShell):
@@ -87,10 +88,16 @@ class Install(Command, ImageSelector):
                                 metavar="LOGFILE_PATH",
                                 action="store",
                                 help="Write image building logs to a file.")
+        self.build_path = Option("--build-path",
+                                 dest="build_path",
+                                 metavar="DOCKERFILES_PATH",
+                                 action="store",
+                                 help=f"Path to the dockerfiles and sources.")
 
         # Create group parameter for container selection
         self.groupArgs.append(GroupArg({"arg": self.build_profile, "required": False},
                                        {"arg": self.build_log, "required": False},
+                                       {"arg": self.build_path, "required": False},
                                        title="[bold cyan]Build[/bold cyan] [blue]specific options[/blue]"))
 
         self._usages = {

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -528,7 +528,7 @@ class DockerUtils:
         return False
 
     @classmethod
-    def buildImage(cls, tag: str, build_profile: Optional[str] = None, build_dockerfile: Optional[str] = None):
+    def buildImage(cls, tag: str, build_profile: Optional[str] = None, build_dockerfile: Optional[str] = None, dockerfile_path: Optional[str] = None):
         """Build a docker image from source"""
         if ParametersManager().offline_mode:
             logger.critical("It's not possible to build a docker image in offline mode. The build process need access to internet ...")
@@ -538,7 +538,7 @@ class DockerUtils:
             build_profile = "full"
             build_dockerfile = "Dockerfile"
         logger.info("Starting build. Please wait, this will be long.")
-        logger.verbose(f"Creating build context from [gold]{ConstantConfig.build_context_path}[/gold] with "
+        logger.verbose(f"Creating build context from [gold]{dockerfile_path}[/gold] with "
                        f"[green][b]{build_profile}[/b][/green] profile ({ParametersManager().arch}).")
         if EnvInfo.arch != ParametersManager().arch:
             logger.warning("Building an image for a different host architecture can cause unexpected problems and slowdowns!")
@@ -547,7 +547,7 @@ class DockerUtils:
             # tag is the name of the final build
             # dockerfile is the Dockerfile filename
             ExegolTUI.buildDockerImage(
-                cls.__client.api.build(path=ConstantConfig.build_context_path,
+                cls.__client.api.build(path=dockerfile_path,
                                        dockerfile=build_dockerfile,
                                        tag=f"{ConstantConfig.IMAGE_NAME}:{tag}",
                                        buildargs={"TAG": f"{build_profile}",

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -528,7 +528,7 @@ class DockerUtils:
         return False
 
     @classmethod
-    def buildImage(cls, tag: str, build_profile: Optional[str] = None, build_dockerfile: Optional[str] = None, dockerfile_path: Optional[str] = None):
+    def buildImage(cls, tag: str, build_profile: Optional[str] = None, build_dockerfile: Optional[str] = None, dockerfile_path: str = ConstantConfig.build_context_path):
         """Build a docker image from source"""
         if ParametersManager().offline_mode:
             logger.critical("It's not possible to build a docker image in offline mode. The build process need access to internet ...")


### PR DESCRIPTION
Adding the `--build-path` that a user can set for the `exegol install` command for local builds to point to custom dockerfiles. This will be especially useful for external contributors that want to build a local image before creating a pull request on the images repo, without having to mess around with their official exegol install.

Before this option, contributors would have to do something like 
```bash
# 1. backup official exegol images submodule
mv "/path/to/Exegol/exegol-docker-build" "/path/to/Exegol/exegol-docker-build.bak"
# 2. overwrite submodule content with custom content
cp -r "/path/to/custom_exegol-docker-build" "/path/to/Exegol/exegol-docker-build"
# 3. build command
exegol install "myimage" "myprofile"
```

This would also allow contributors to have their own forks as well as their official exegol install without changes that they would be able to keep up to date (which wouldn't be possible if they were to change things locally without staging commits)