### PR TITLE
Wayland support

### DIFF
--- a/exegol/config/EnvInfo.py
+++ b/exegol/config/EnvInfo.py
@@ -1,4 +1,5 @@
 import json
+import os
 import platform
 from enum import Enum
 from typing import Optional, Any, List
@@ -16,6 +17,11 @@ class EnvInfo:
         WINDOWS = "Windows"
         LINUX = "Linux"
         MAC = "Mac"
+    
+    class DisplayServer(Enum):
+        """Dictionary class for static Display Server"""
+        WAYLAND = "Wayland"
+        X11 = "X11"
 
     class DockerEngine(Enum):
         """Dictionary class for static Docker engine name"""
@@ -108,6 +114,18 @@ class EnvInfo:
         return cls.__docker_host_os
 
     @classmethod
+    def getDisplayServer(cls) -> DisplayServer:
+        """Returns the display server
+        Can be 'X11' or 'Wayland'"""
+        if "wayland" in os.getenv("XDG_SESSION_TYPE"):
+            return cls.DisplayServer.WAYLAND
+        elif "x11" in os.getenv("XDG_SESSION_TYPE"):
+            return cls.DisplayServer.X11
+        else:
+            # Should return an error
+            return os.getenv("XDG_SESSION_TYPE")
+
+    @classmethod
     def getWindowsRelease(cls) -> str:
         # Cache check
         if cls.__windows_release is None:
@@ -127,6 +145,16 @@ class EnvInfo:
     def isMacHost(cls) -> bool:
         """Return true if macOS is detected on the host"""
         return cls.getHostOs() == cls.HostOs.MAC
+
+    @classmethod
+    def isX11(cls) -> bool:
+        """Return true if x11 is detected on the host"""
+        return cls.getDisplayServer() == cls.DisplayServer.X11
+
+    @classmethod
+    def isWayland(cls) -> bool:
+        """Return true if wayland is detected on the host"""
+        return cls.getDisplayServer() == cls.DisplayServer.WAYLAND
 
     @classmethod
     def isDockerDesktop(cls) -> bool:

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -1080,9 +1080,17 @@ class ContainerConfig:
         result = []
         # Select default shell to use
         result.append(f"{self.ExegolEnv.user_shell.value}={ParametersManager().shell}")
-        # Share X11 (GUI Display) config
+        # Manage the GUI
         if self.__enable_gui:
             current_display = GuiUtils.getDisplayEnv()
+
+            # Wayland
+            if EnvInfo.isWayland():
+                result.append(f"WAYLAND_DISPLAY={current_display}")
+                result.append(f"XDG_RUNTIME_DIR=/tmp")
+
+            # Share X11 (GUI Display) config
+
             # If the default DISPLAY environment in the container is not the same as the DISPLAY of the user's session,
             # the environment variable will be updated in the exegol shell.
             if current_display and self.__envs.get('DISPLAY', '') != current_display:

--- a/exegol/utils/GuiUtils.py
+++ b/exegol/utils/GuiUtils.py
@@ -61,9 +61,17 @@ class GuiUtils:
     @classmethod
     def getDisplayEnv(cls) -> str:
         """
-        Get the current DISPLAY env to access X11 socket
+        Get the current DISPLAY environment to access the display server
         :return:
         """
+        if EnvInfo.isWayland():
+            # Wayland
+            return os.getenv('WAYLAND_DISPLAY', 'wayland-1')
+
+        if EnvInfo.isX11():
+            # X11
+            return os.getenv('DISPLAY', ":0")
+
         if EnvInfo.isMacHost():
             # xquartz Mac mode
             return "host.docker.internal:0"


### PR DESCRIPTION
# Description

Hey @Dramelac,

Here's an addition to set the correct environment variables for **wayland**. I started with this observation:

```bash
docker run -it -e XDG_RUNTIME_DIR=/tmp -e WAYLAND_DISPLAY=$WAYLAND_DISPLAY -v $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/$WAYLAND_DISPLAY debian bash
```

```bash
➜  ~ echo $WAYLAND_DISPLAY
wayland-1
```

```bash
[*] Location of the exegol workspace on the host : /home/qu35t/.exegol/workspaces/htb
[+] Opening shell in Exegol 'htb'
[-] The xhost command is not available on your host. Exegol was unable to allow your container to access your graphical environment (or you don't have one).
[Jan 26, 2024 - 21:53:47 (CET)] exegol-htb /workspace # firefox
Authorization required, but no authorization protocol specified

Error: cannot open display: :0
```

I've modified the code to add a check on the display server and return the correct environment variables if this is the case.
There's one step missing (and I'm struggling):

You need to add a volume:

```bash
-v $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/$WAYLAND_DISPLAY
```

With my modifications, the following command works: (the **xhost** warning must also be removed)

```bash
(venv) ➜  Exegol git:(wayland) python3 exegol.py start -V $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/$WAYLAND_DISPLAY wayland2
[*] Exegol is currently in version v4.3.1
[*] Exegol Discord serv.: https://discord.gg/cXThyp7D6P
[*] Exegol documentation: https://exegol.rtfd.io/
[+] We thank Capgemini for supporting the project (helping with dev) 🙏
[+] We thank HackTheBox for sponsoring the multi-arch support 💚
[*] Starting exegol
[*] Arguments supplied with the command, skipping interactive mode

🛸 Available images
┌───────────┬─────────┬─────────────────────────┐
│ Image tag │ Size    │ Status                  │
├───────────┼─────────┼─────────────────────────┤
│ nightly   │ 50.5GB  │ Up to date (v.58d605bb) │
│ web       │ ~23.5GB │ Not installed           │
│ osint     │ ~13.3GB │ Not installed           │
│ light     │ ~14.2GB │ Not installed           │
│ full      │ ~55.3GB │ Not installed           │
│ ad        │ ~40.4GB │ Not installed           │
└───────────┴─────────┴─────────────────────────┘

[*] You can use a name that does not already exist to build a new image from local sources
[?] Select an image by its name (nightly):

⭐ Container summary
┌──────────────────┬───────────────────────────────────────────┐
│             Name │ wayland2                                  │
│            Image │ nightly - v.58d605bb (Up to date)         │
├──────────────────┼───────────────────────────────────────────┤
│      Credentials │ root : oq3PEox5VLkNHpCRulmhJL0Pay0pTI     │
│          Desktop │ Off 🪓                                    │
│              X11 │ On ✔                                      │
│          Network │ host                                      │
│         Timezone │ On ✔                                      │
│ Exegol resources │ On ✔ (/opt/resources)                     │
│     My resources │ On ✔ (/opt/my-resources)                  │
│    Shell logging │ Off 🪓                                    │
│       Privileged │ Off ✔                                     │
│        Workspace │ Dedicated (/workspace)                    │
│          Volumes │ /run/user/1000/wayland-1 ➡ /tmp/wayland-1 │
└──────────────────┴───────────────────────────────────────────┘

[*] Creating new exegol container
[+] Exegol container successfully created !
[-] The xhost command is not available on your host. Exegol was unable to allow your container to access your graphical environment (or you don't have one).
[*] Location of the exegol workspace on the host : /home/qu35t/.exegol/workspaces/wayland2
[+] Opening shell in Exegol 'wayland2'
[Jan 26, 2024 - 22:56:19 (CET)] exegol-wayland2 /workspace #
```

```bash
[Jan 26, 2024 - 22:57:14 (CET)] exegol-wayland2 /workspace # env|grep -i wayland
HOSTNAME=exegol-wayland2
WAYLAND_DISPLAY=wayland-1
DISPLAY=wayland-1
```

![image](https://github.com/ThePorgs/Exegol/assets/51704860/6fa7bb2a-1ea8-4b86-8af4-50f41ccab916)
