### PR TITLE
FEATURE - Add range port

### DIFF
--- a/exegol/console/cli/SyntaxFormat.py
+++ b/exegol/console/cli/SyntaxFormat.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class SyntaxFormat(Enum):
+    port_sharing = "[default green not bold][<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>][/default green not bold]"
+    desktop_config = "[blue]proto[:ip[:port]][/blue]"
+    volume = "/path/on/host/:/path/in/container/[blue][:ro|rw][/blue]"
+
+    def __str__(self):
+        return self.value

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -4,6 +4,7 @@ from argcomplete.completers import EnvironCompleter, DirectoriesCompleter, Files
 
 from exegol.config.UserConfig import UserConfig
 from exegol.console.cli.ExegolCompleter import ContainerCompleter, ImageCompleter, VoidCompleter, DesktopConfigCompleter
+from exegol.console.cli.SyntaxFormat import SyntaxFormat
 from exegol.console.cli.actions.Command import Option, GroupArg
 
 
@@ -191,12 +192,12 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               action="append",
                               default=[],
                               dest="volumes",
-                              help="Share a new volume between host and exegol (format: --volume /path/on/host/:/path/in/container/[blue][:ro|rw][/blue])")
+                              help=f"Share a new volume between host and exegol (format: --volume {SyntaxFormat.volume})")
         self.ports = Option("-p", "--port",
                             action="append",
                             default=[],
                             dest="ports",
-                            help="Share a network port between host and exegol (format: --port [<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>]. This configuration will disable the shared network with the host.",
+                            help=f"Share a network port between host and exegol (format: --port {SyntaxFormat.port_sharing}). This configuration will disable the default host network.",
                             completer=VoidCompleter)
         self.hostname = Option("--hostname",
                                dest="hostname",
@@ -274,7 +275,7 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                                      default="",
                                      action="store",
                                      help=f"Configure your exegol desktop ([blue]{'[/blue] or [blue]'.join(UserConfig.desktop_available_proto)}[/blue]) and its exposure "
-                                          f"(format: [blue]proto[:ip[:port]][/blue]) "
+                                          f"(format: {SyntaxFormat.desktop_config}) "
                                           f"(default: [blue]{UserConfig().desktop_default_proto}[/blue]:[blue]{'127.0.0.1' if UserConfig().desktop_default_localhost else '0.0.0.0'}[/blue]:[blue]<random>[/blue])",
                                      completer=DesktopConfigCompleter)
         groupArgs.append(GroupArg({"arg": self.desktop, "required": False},

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -196,7 +196,7 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                             action="append",
                             default=[],
                             dest="ports",
-                            help="Share a network port between host and exegol (format: --port [<host_ipv4>:]<host_port>[:<container_port>][:<protocol>]. This configuration will disable the shared network with the host.",
+                            help="Share a network port between host and exegol (format: --port [<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>]. This configuration will disable the shared network with the host.",
                             completer=VoidCompleter)
         self.hostname = Option("--hostname",
                                dest="hostname",

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -559,7 +559,7 @@ class ContainerConfig:
     def __disableDesktop(self):
         """Procedure to disable exegol desktop feature"""
         if self.isDesktopEnabled():
-            logger.verbose("Config: Disabling exegol desktop")
+            logger.verbose("Config: Disabling shell logging")
             assert self.__desktop_proto is not None
             if not self.__network_host:
                 self.__removePort(self.__default_desktop_port[self.__desktop_proto])

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -1242,7 +1242,7 @@ class ContainerConfig:
         # Regex to capture port ranges and protocols correctly
         match = re.search(r"^((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):)?(\d+)(-(\d+))?:?(\d+)?(-(\d+))?:?(udp|tcp|sctp)?$", user_test_port)
         if match is None:
-            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: [green][<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>][/green]")
+            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: '[<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>]'")
             return
         host_ip = "0.0.0.0" if match.group(2) is None else match.group(2)
         protocol = match.group(9) if match.group(9) else 'tcp'
@@ -1259,7 +1259,7 @@ class ContainerConfig:
                 end_container_port = int(match.group(8)) if match.group(8) else start_container_port
             # check port consistency
             if (len(range(start_host_port,end_host_port)) != len(range(start_container_port,end_container_port))) or (start_host_port != end_host_port and (not start_container_port_defined and end_container_port_defined)) or (start_host_port != end_host_port and (start_container_port_defined and not end_container_port_defined)) :
-                logger.info(f"Ports sharing configuration could be wrong ({user_test_port}). The configuration in the 'Container sumamry' below will be applied.")
+                logger.info(f"Port sharing configuration does not respect standard usage ({user_test_port}). The configuration in the 'Container sumamry' below will be applied. Please consult the help section for more information on using the -p/--port option.")
             # Check if start port is lower than end port
             if end_host_port < start_host_port or end_container_port < start_container_port:
                 raise ValueError("End port cannot be less than start port.")

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -559,7 +559,7 @@ class ContainerConfig:
     def __disableDesktop(self):
         """Procedure to disable exegol desktop feature"""
         if self.isDesktopEnabled():
-            logger.verbose("Config: Disabling shell logging")
+            logger.verbose("Config: Disabling exegol desktop")
             assert self.__desktop_proto is not None
             if not self.__network_host:
                 self.__removePort(self.__default_desktop_port[self.__desktop_proto])
@@ -1234,26 +1234,41 @@ class ContainerConfig:
         self.__addDevice(user_device_config)
 
     def addRawPort(self, user_test_port: str):
-        """Add port config from user input.
-        Format must be [<host_ipv4>:]<host_port>[:<container_port>][:<protocol>]
+        """Add port config or range of ports from user input.
+        Format must be [<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>]
         If host_ipv4 is not set, default to 0.0.0.0
-        If container_port is not set, default is the same as host port
+        If container_port is not set, the same port(s) as host port(s) will be used
         If protocol is not set, default is 'tcp'"""
-        match = re.search(r"^((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):)?(\d+):?(\d+)?:?(udp|tcp|sctp)?$", user_test_port)
+        # Regex to capture port ranges and protocols correctly
+        match = re.search(r"^((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):)?(\d+)(-(\d+))?:?(\d+)?(-(\d+))?:?(udp|tcp|sctp)?$", user_test_port)
         if match is None:
-            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: [green][<host_ipv4>:]<host_port>[:<container_port>][:<protocol>][/green]")
+            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use the correct format.")
             return
+        
         host_ip = "0.0.0.0" if match.group(2) is None else match.group(2)
-        protocol = "tcp" if match.group(5) is None else match.group(5)
-        try:
-            host_port = int(match.group(3))
-            container_port = host_port if match.group(4) is None else int(match.group(4))
-            if host_port > 65535 or container_port > 65535:
-                raise ValueError
-        except ValueError:
-            logger.critical(f"The syntax for opening prot in NAT is incorrect. The ports must be numbers between 0 and 65535. ({match.group(3)}:{match.group(4)})")
+        start_host_port = int(match.group(3))
+        end_host_port = int(match.group(5)) if match.group(5) else start_host_port
+        start_container_port = int(match.group(6)) if match.group(6) else start_host_port
+        end_container_port = int(match.group(8)) if match.group(8) else end_host_port
+        protocol = match.group(9) if match.group(9) else 'tcp'
+
+        # Check if start port is lower than end port
+        if end_host_port < start_host_port or end_container_port < start_container_port:
+            logger.critical("End port cannot be less than start port.")
             return
-        self.addPort(host_port, container_port, protocol=protocol, host_ip=host_ip)
+
+        # Check if any port in the range exceeds the valid range
+        if end_host_port > 65535 or end_container_port > 65535:
+            logger.critical(f"The syntax for opening prot in NAT is incorrect. The ports must be numbers between 0 and 65535. ({end_host_port}:{end_container_port})")
+            return
+
+        try:
+            for host_port, container_port in zip(range(start_host_port, end_host_port + 1), range(start_container_port, end_container_port + 1)):
+                self.addPort(host_port, container_port, protocol=protocol, host_ip=host_ip)
+        except ValueError as e:
+            logger.critical(f"The syntax for opening prot in NAT is incorrect. The format must be [<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>] ({match.group(3)}:{match.group(4)})")
+
+
 
     def addRawEnv(self, env: str):
         """Parse and add an environment variable from raw user input"""

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -14,6 +14,7 @@ from docker.models.containers import Container
 from docker.types import Mount
 from rich.prompt import Prompt
 
+from exegol.console.cli.SyntaxFormat import SyntaxFormat
 from exegol.config.ConstantConfig import ConstantConfig
 from exegol.config.EnvInfo import EnvInfo
 from exegol.config.UserConfig import UserConfig
@@ -512,7 +513,7 @@ class ContainerConfig:
 
     def configureDesktop(self, desktop_config: str, create_mode: bool = False):
         """Configure the exegol desktop feature from user parameters.
-        Accepted format: 'mode:host:port'
+        Accepted format: 'proto:host:port'
         """
         self.__desktop_proto = UserConfig().desktop_default_proto
         self.__desktop_host = "127.0.0.1" if UserConfig().desktop_default_localhost else "0.0.0.0"
@@ -537,7 +538,7 @@ class ContainerConfig:
                 except ValueError:
                     logger.critical(f"Invalid desktop port: '{data}' is not a valid port.")
             else:
-                logger.critical(f"Your configuration is invalid, please use the following format:[green]mode:host:port[/green]")
+                logger.critical(f"Your configuration is invalid, please use the following format: {SyntaxFormat.desktop_config}")
 
         if self.__desktop_port is None:
             logger.debug(f"Desktop port will be set automatically")
@@ -1244,7 +1245,7 @@ class ContainerConfig:
         # Regex to capture port ranges and protocols correctly
         match = re.search(r"^((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):)?(\d+)(-(\d+))?:?(\d+)?(-(\d+))?:?(udp|tcp|sctp)?$", user_test_port)
         if match is None:
-            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: '[<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>]'")
+            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: '{SyntaxFormat.port_sharing}'")
             return
         host_ip = "0.0.0.0" if match.group(2) is None else match.group(2)
         protocol = match.group(9) if match.group(9) else 'tcp'

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -1242,7 +1242,7 @@ class ContainerConfig:
         # Regex to capture port ranges and protocols correctly
         match = re.search(r"^((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):)?(\d+)(-(\d+))?:?(\d+)?(-(\d+))?:?(udp|tcp|sctp)?$", user_test_port)
         if match is None:
-            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: [<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>].")
+            logger.critical(f"Incorrect port syntax ({user_test_port}). Please use this format: [green][<host_ipv4>:]<host_port>[-<end_host_port>][:<container_port>[-<end_container_port>]][:<protocol>][/green]")
             return
         host_ip = "0.0.0.0" if match.group(2) is None else match.group(2)
         protocol = match.group(9) if match.group(9) else 'tcp'


### PR DESCRIPTION
# Description

Code modified to expose port ranges rather than just ports.

In fact, in environments where it's not possible to have a bridged network, it's a pain to expose several ports at once.

The port exposure feature has been changed to allow commands of this kind: 

exegol start dev -p 9000-9010:9000-9010 -p 80 -p 802-805:udp

# Point of attention

The feature has been extensively tested, but I have two points to make.

1. Creation timeout

First of all, if a port range is too large, it is possible to be timeout by exegol.

More precisely, if the machine takes longer than 60 seconds to create, exegol stops. I didn't touch this behavior to avoid blocking the user. In this case, the long creation time is not linked to exegol but to docker.

It's starting to be difficult to create a container with more than 2500 published ports.

Once again, this is specific to docker and exegol would behave in the same way as if you used the --ports option 2500 times. 

ref : 
https://forums.docker.com/t/i-have-a-docker-container-that-needs-to-expose-10-000-ports/96048/3
https://github.com/moby/moby/issues/14288

2. Display port

Similar effect on port display. Ports are displayed in sequence and not by range. For standard use, there's no visual imapact, but for exposing hundreds of ports, this has an impact on the visibility of the creation summary.

I did some local tests to manage the display a little better. 

But I find the current interface more reassuring (ports are clearly visible).

To sum up, the modification also meant a significant increase in the complexity of the code and a less clear interface.

