### PR TITLE
Release 4.3.6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Handle python file as text
+*.py text
+
+# Every shell file must be cloned with LF line ending
+*.sh text eol=lf

--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - "dev"
-    paths:
-      - "**.py"
+    #paths:
+    #  - "**.py"
 
 jobs:
   test:

--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install requirements
-        run: python -m pip install --user build virtualenv
+        run: python -m pip install --user build virtualenv setuptools
       - name: Cleaning
         run : python setup.py clean
       - name: Build Exegol

--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -29,11 +29,15 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install requirements
-        run: python -m pip install --user build
+        run: python -m pip install --user build venv
       - name: Cleaning
         run : python setup.py clean
       - name: Build Exegol
         run: python -m build --sdist --outdir dist/ .
+      - name: Create testing venv
+        run: python -m venv vtest
+      - name: Install pip package
+        run: ./vtest/bin/pip install ./dist/*
       - name: Publish distribution 📦 to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install requirements
-        run: python -m pip install --user build venv
+        run: python -m pip install --user build virtualenv
       - name: Cleaning
         run : python setup.py clean
       - name: Build Exegol

--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Install requirements
         run: python -m pip install --user build virtualenv
       - name: Cleaning

--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class ConstantConfig:
     """Constant parameters information"""
     # Exegol Version
-    version: str = "4.3.5"
+    version: str = "4.3.6"
 
     # Exegol documentation link
     documentation: str = "https://exegol.rtfd.io/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ rich~=13.7.1
 GitPython~=3.1.43
 PyYAML>=6.0.2
 argcomplete~=3.5.0
-tzlocal~=5.2
+tzlocal~=5.2; platform_system != 'Linux'

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,6 @@ data_files_dict["exegol-imgsync"] = ["exegol/utils/imgsync/entrypoint.sh",
 for k, v in data_files_dict.items():
     data_files.append((k, v))
 
-with open("requirements.txt", "r", encoding="utf-8") as f:
-    requirements = [x.strip() for x in f.readlines()]
-
 setup(
     name='Exegol',
     version=__version__,
@@ -57,7 +54,15 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    install_requires=requirements,
+    install_requires=[
+        'docker~=7.1.0',
+        'requests~=2.32.3',
+        'rich~=13.7.1',
+        'GitPython~=3.1.43',
+        'PyYAML>=6.0.2',
+        'argcomplete~=3.5.0',
+        'tzlocal~=5.2; platform_system != "Linux"'
+    ],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     data_files=data_files,

--- a/tests/test_exegol.py
+++ b/tests/test_exegol.py
@@ -2,4 +2,4 @@ from exegol import __version__
 
 
 def test_version():
-    assert __version__ == '4.3.5'
+    assert __version__ == '4.3.6'


### PR DESCRIPTION
# Description

- New tests before release
- Update tzlocal requirement only for Mac and Windows environments

# Related issues

- Fix pip package requirements error
- Force windows env to clone bash script with LF linefeed
