### PR TITLE
Adding support for x11 forwarding

### DIFF
--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -344,7 +344,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
             # Extracts the left part of the display variable to determine if remote access is used
             display_host = GuiUtils.getDisplayEnv().split(':')[0]
             # Left part is empty, local access is used to start Exegol
-            if display_host=='':
+            if display_host=='' or EnvInfo.isMacHost():
                 logger.debug("Connecting to container from local GUI, no X11 forwarding to set up")
                 # TODO verify that the display format is the same on macOS, otherwise might not set up xauth and xhost correctly
                 if EnvInfo.isMacHost():

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import random
+import tempfile
 import shutil
 from datetime import datetime
 from typing import Optional, Dict, Sequence, Tuple, Union
@@ -328,6 +328,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         On Windows host, WSLg X11 don't have xhost ACL. #TODO xauth remote x11 forwarding
         :return:
         """
+        # TODO check if the xauth propagation should be performed on Windows, if so remove the "and not EnvInfo.isWindowsHost()"
         if self.config.isGUIEnable() and not self.__xhost_applied and not EnvInfo.isWindowsHost():
             self.__xhost_applied = True  # Can be applied only once per execution
             if shutil.which("xhost") is None:
@@ -340,17 +341,18 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                 return
             
             logger.debug(f"DISPLAY variable: {GuiUtils.getDisplayEnv()}")
-
+            # Extracts the left part of the display variable to determine if remote access is used
             display_host = GuiUtils.getDisplayEnv().split(':')[0]
+            # Left part is empty, local access is used to start Exegol
             if display_host=='':
                 logger.debug("Connecting to container from local GUI, no X11 forwarding to set up")
-                # TODO verify that the display format is the same on macOS, otherwise might not set up xauth and xhost correctly 
+                # TODO verify that the display format is the same on macOS, otherwise might not set up xauth and xhost correctly
                 if EnvInfo.isMacHost():
                     logger.debug(f"Adding xhost ACL to localhost")
                     # add xquartz inet ACL
                     with console.status(f"Starting XQuartz...", spinner_style="blue"):
                         os.system(f"xhost + localhost > /dev/null")
-                else:
+                elif not EnvInfo.isWindowsHost():
                     logger.debug(f"Adding xhost ACL to local:{self.config.getUsername()}")
                     # add linux local ACL
                     os.system(f"xhost +local:{self.config.getUsername()} > /dev/null")
@@ -358,31 +360,37 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
             
             if shutil.which("xauth") is None:
                 if EnvInfo.is_linux_shell:
-                    debug_msg = "Try to install the package [green]xorg-xauth[/green] or maybe you don't have X11 on your host?"
+                    debug_msg = "Try to install the package [green]xorg-xauth[/green] to support X11 forwarding in your current environment?"
                 else:
-                    debug_msg = "or you don't have one"
+                    debug_msg = "or it might not be supported for now"
                 logger.error(f"The [green]xauth[/green] command is not available on your [bold]host[/bold]. "
                              f"Exegol was unable to allow your container to access your graphical environment ({debug_msg}).")
                 return
             
-            if display_host=="localhost" and self.config.getTextNetworkMode() != "host":
+            # If the left part of the display variable is "localhost", x11 socket is exposed only on loopback and remote access is used
+            # If the container is not in host mode, it won't be able to reach the loopback interface of the host 
+            if display_host=="localhost" and self.config.getNetworkMode() != "host":
                 logger.warning("X11 forwarding won't work on a bridged container unless you specify \"X11UseLocalhost no\" in your host sshd_config")
                 logger.warning("[red]Be aware[/red] changing \"X11UseLocalhost\" value can [red]expose your device[/red], correct firewalling is [red]required[/red]")
-                logger.warning("The following documentation can be usefull to limit the exposure of your x11 socket: https://studioware.com/wikislax/index.php?title=X11_over_the_network#X11_firewalling")
+                # TODO Add documentation to restrict the exposure of the x11 socket to the docker subnet
                 return
 
-            # Setting up the temporary file to pass the xauth cookie to the container
-            tmpXauthority = f"/tmp/.tmpXauthority{random.randint(0, 999)}"
+            # Extracting the xauth cookie corresponding to the current display to a temporary file and reading it from there (grep cannot be used because display names are not accurate enough)
+            _, tmpXauthority = tempfile.mkstemp()
             logger.debug(f"Extracting xauth entries to {tmpXauthority}")
             os.system(f"xauth extract {tmpXauthority} $DISPLAY > /dev/null 2>&1")
             xauthEntry = subprocess.check_output(f"xauth -f {tmpXauthority} list 2>/dev/null",shell=True).decode()
             logger.debug(f"xauthEntry to propagate: {xauthEntry}")
+
+            # Replacing the hostname with localhost to support loopback exposed x11 socket and container in host mode (loopback is the same)
             if display_host=="localhost":
-                logger.debug("X11UseLocalhost directive is set to \"yes\" or unspecified, X11 connection can be received only on loopback");
+                logger.debug("X11UseLocalhost directive is set to \"yes\" or unspecified, X11 connections can be received only on loopback");
                 # Modifing the entry to convert <hostname>/unix:<display_number> to localhost:<display_number>
                 xauthEntry = f"localhost:{xauthEntry.split(':')[1]}"
             else:
-                logger.debug("X11UseLocalhost directive is set to \"no\", X11 connection can be received from anywere");
+                # TODO latter implement a check to see if the x11 socket is correctly firewalled and warn the user if it is not
+                logger.debug("X11UseLocalhost directive is set to \"no\", X11 connections can be received from anywere");
+            
             # Check if the host has a xauth entry corresponding to the current display.
             if xauthEntry:
                 logger.debug(f"Adding xauth cookie to container: {xauthEntry}")


### PR DESCRIPTION
# Description

This PR aims to bring support for X11 forwarding when the host is accessed by SSH from a remote location running a X server.

On top of xhost ACLs I created a secret sharing mechanism between the host and the Exegol container.

# Related issues

Some people on the discord server were asking about forwarding the GUI of Exegol containers to a remote location.

# Point of attention

## Tested setups

I tried this solution with only 2 setups: 
* Linux ==SSH==> Linux ==WRAPPER==> Exegol container
* Windows ==SSH==> Linux ==WRAPPER==> Exegol container

The following setups are yet to be tested:
* ? ==SSH==> Mac ==WRAPPER==> Exegol container
* ? ==SSH==> Windows ==WRAPPER==> Exegol container

## Library added

I imported the subprocess library to get the output of a command. An alternative would be to create a file in the container workspace to pass the xauth cookie with `os.system()`.

## X11UseLocalhost limitation

The `X11UseLocalhost` directive has its importance. When it is set to "yes", the X11 server will be listening on the loopback interface only. This causes a limitation, when the network interface of an Exegol container is bridged, it won't be able to forward its GUI to the remote server.

## xhost ACLs
xhost ACLs need to be applied on the machine running the X server. Because it is no longer the host when accessing remotely, it is not needed. Moreover, the xhost commands cannot be executed from a SSH shell.