### PR TITLE
Release 4.3.7

### DIFF
--- a/.github/workflows/entrypoint_prerelease.yml
+++ b/.github/workflows/entrypoint_prerelease.yml
@@ -53,10 +53,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install requirements
-        run: python -m pip install --user build
+        run: python -m pip install --user build virtualenv setuptools
       - name: Cleaning
         run : python setup.py clean test
       - name: Build Exegol
         run: python -m build --sdist --outdir dist/ .
+      - name: Create testing venv
+        run: python -m venv vtest
+      - name: Install pip package
+        run: ./vtest/bin/pip install ./dist/*

--- a/.github/workflows/entrypoint_pull_request.yml
+++ b/.github/workflows/entrypoint_pull_request.yml
@@ -44,10 +44,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install requirements
-        run: python -m pip install --user build
+        run: python -m pip install --user build virtualenv setuptools
       - name: Cleaning
         run : python setup.py clean
       - name: Build Exegol
         run: python -m build --sdist --outdir dist/ .
+      - name: Create testing venv
+        run: python -m venv vtest
+      - name: Install pip package locally
+        run: ./vtest/bin/pip install ./dist/*

--- a/.github/workflows/entrypoint_pull_request.yml
+++ b/.github/workflows/entrypoint_pull_request.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches-ignore:
       - "dev"
+      - "master"
     paths-ignore:
       - ".github/**"
       - "**.md"

--- a/.github/workflows/entrypoint_release.yml
+++ b/.github/workflows/entrypoint_release.yml
@@ -25,13 +25,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install requirements
-        run: python -m pip install --user build
+        run: python -m pip install --user build virtualenv setuptools
       - name: Run package unitest
         run : python setup.py clean test
       - name: Build Exegol release
         run: python -m build --sdist --outdir dist/ .
+      - name: Create testing venv
+        run: python -m venv vtest
+      - name: Install pip package locally
+        run: ./vtest/bin/pip install ./dist/*
       #- name: Publish distribution 📦 to Test PyPI
       #  uses: pypa/gh-action-pypi-publish@release/v1
       #  with:

--- a/exegol/config/UserConfig.py
+++ b/exegol/config/UserConfig.py
@@ -24,6 +24,7 @@ class UserConfig(DataFileUtils, metaclass=MetaSingleton):
         self.auto_remove_images: bool = True
         self.auto_update_workspace_fs: bool = False
         self.default_start_shell: str = "zsh"
+        self.enable_exegol_resources: bool = True
         self.shell_logging_method: str = "asciinema"
         self.shell_logging_compress: bool = True
         self.desktop_default_enable: bool = False
@@ -61,6 +62,9 @@ config:
     # Default shell command to start
     default_start_shell: {self.default_start_shell}
     
+    # Enable Exegol resources
+    enable_exegol_resources: {self.enable_exegol_resources}
+    
     # Change the configuration of the shell logging functionality
     shell_logging: 
         #Choice of the method used to record the sessions (script or asciinema)
@@ -82,8 +86,6 @@ config:
         localhost_by_default: {self.desktop_default_localhost}
 
 """
-        # TODO handle default image selection
-        # TODO handle default start container
         return config
 
     @staticmethod
@@ -115,6 +117,7 @@ config:
         self.auto_remove_images = self._load_config_bool(config_data, 'auto_remove_image', self.auto_remove_images)
         self.auto_update_workspace_fs = self._load_config_bool(config_data, 'auto_update_workspace_fs', self.auto_update_workspace_fs)
         self.default_start_shell = self._load_config_str(config_data, 'default_start_shell', self.default_start_shell, choices=self.start_shell_options)
+        self.enable_exegol_resources = self._load_config_bool(config_data, 'enable_exegol_resources', self.enable_exegol_resources)
 
         # Shell_logging section
         shell_logging_data = config_data.get("shell_logging", {})
@@ -132,7 +135,9 @@ config:
         configs = [
             f"User config file: [magenta]{self._file_path}[/magenta]",
             f"Private workspace: [magenta]{self.private_volume_path}[/magenta]",
-            f"Exegol resources: [magenta]{self.exegol_resources_path}[/magenta]",
+            "Exegol resources: " + (f"[magenta]{self.exegol_resources_path}[/magenta]"
+                                    if self.enable_exegol_resources else
+                                    boolFormatter(self.enable_exegol_resources)),
             f"My resources: [magenta]{self.my_resources_path}[/magenta]",
             f"Auto-check updates: {boolFormatter(self.auto_check_updates)}",
             f"Auto-remove images: {boolFormatter(self.auto_remove_images)}",

--- a/exegol/manager/ExegolController.py
+++ b/exegol/manager/ExegolController.py
@@ -1,9 +1,11 @@
+import http
 import logging
 
 try:
     import docker
-    import requests
     import git
+    import requests
+    import urllib3
 
     from exegol.utils.ExeLog import logger, ExeLog, console
     from exegol.utils.DockerUtils import DockerUtils
@@ -83,5 +85,5 @@ def main():
         logger.critical(f"A critical error occurred while running this git command: {' '.join(git_error.command)}")
     except Exception:
         print_exception_banner()
-        console.print_exception(show_locals=True, suppress=[docker, requests, git])
+        console.print_exception(show_locals=True, suppress=[docker, requests, git, urllib3, http])
         exit(1)

--- a/exegol/manager/UpdateManager.py
+++ b/exegol/manager/UpdateManager.py
@@ -1,12 +1,12 @@
 import re
-from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Optional, Dict, cast, Tuple, Sequence
-from pathlib import Path, PurePath
 
 from rich.prompt import Prompt
 
 from exegol.config.ConstantConfig import ConstantConfig
 from exegol.config.DataCache import DataCache
+from exegol.config.UserConfig import UserConfig
 from exegol.console.ExegolPrompt import Confirm
 from exegol.console.TUI import ExegolTUI
 from exegol.console.cli.ParametersManager import ParametersManager
@@ -117,6 +117,9 @@ class UpdateManager:
     @classmethod
     def updateResources(cls) -> bool:
         """Update Exegol-resources from git (submodule)"""
+        if not UserConfig().enable_exegol_resources:
+            logger.info("Skipping disabled Exegol resources.")
+            return False
         try:
             if not ExegolModules().isExegolResourcesReady() and not Confirm('Do you want to update exegol resources.', default=True):
                 return False

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -501,7 +501,8 @@ class ContainerConfig:
                     raise CancelOperation
             except CancelOperation:
                 # Error during installation, skipping operation
-                logger.warning("Exegol resources have not been downloaded, the feature cannot be enabled")
+                if UserConfig().enable_exegol_resources:
+                    logger.warning("Exegol resources have not been downloaded, the feature cannot be enabled yet")
                 return False
             logger.verbose("Config: Enabling exegol resources volume")
             self.__exegol_resources = True

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -24,7 +24,7 @@ from exegol.exceptions.ExegolExceptions import ProtocolNotSupported, CancelOpera
 from exegol.model.ExegolModules import ExegolModules
 from exegol.utils import FsUtils
 from exegol.utils.ExeLog import logger, ExeLog
-from exegol.utils.FsUtils import check_sysctl_value
+from exegol.utils.FsUtils import check_sysctl_value, mkdir
 from exegol.utils.GuiUtils import GuiUtils
 
 if EnvInfo.is_windows_shell or EnvInfo.is_mac_shell:
@@ -1039,7 +1039,7 @@ class ContainerConfig:
                     else:
                         # If the directory is created by exegol, bypass user preference and enable shared perms (if available)
                         execute_update_fs = force_sticky_group or enable_sticky_group
-                        path.mkdir(parents=True, exist_ok=True)
+                        mkdir(path)
             except PermissionError:
                 logger.error("Unable to create the volume folder on the filesystem locally.")
                 logger.critical(f"Insufficient permissions to create the folder: {host_path}")

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -118,7 +118,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         :return:
         """
         with console.status(f"Waiting to start {self.name}", spinner_style="blue") as progress:
-            start_date = datetime.utcnow()
+            start_date = datetime.now()
             try:
                 self.__container.start()
             except APIError as e:

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -193,7 +193,9 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                 # stream[0] : exit code
                 # stream[1] : text stream
                 for log in stream[1]:
-                    logger.raw(log.decode("utf-8"))
+                    if type(log) is bytes:
+                        log = log.decode("utf-8")
+                    logger.raw(log)
                 if not quiet:
                     logger.success("End of the command")
             except KeyboardInterrupt:

--- a/exegol/model/ExegolModules.py
+++ b/exegol/model/ExegolModules.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 from typing import Optional, Union
 
+from exegol.config.ConstantConfig import ConstantConfig
+from exegol.config.UserConfig import UserConfig
 from exegol.console.ExegolPrompt import Confirm
 from exegol.console.cli.ParametersManager import ParametersManager
 from exegol.exceptions.ExegolExceptions import CancelOperation
-from exegol.config.ConstantConfig import ConstantConfig
 from exegol.utils.ExeLog import logger
 from exegol.utils.GitUtils import GitUtils
 from exegol.utils.MetaSingleton import MetaSingleton
-from exegol.config.UserConfig import UserConfig
 
 
 class ExegolModules(metaclass=MetaSingleton):
@@ -51,7 +51,7 @@ class ExegolModules(metaclass=MetaSingleton):
         if self.__git_resources is None:
             self.__git_resources = GitUtils(UserConfig().exegol_resources_path, "resources", "",
                                             skip_submodule_update=fast_load)
-        if not self.__git_resources.isAvailable and not skip_install:
+        if not self.__git_resources.isAvailable and not skip_install and UserConfig().enable_exegol_resources:
             self.__init_resources_repo()
         return self.__git_resources
 

--- a/exegol/utils/ContainerLogStream.py
+++ b/exegol/utils/ContainerLogStream.py
@@ -1,12 +1,8 @@
-import asyncio
-import concurrent.futures
-import threading
 import time
 from datetime import datetime, timedelta
-from typing import Union, List, Any, Optional
+from typing import Optional
 
 from docker.models.containers import Container
-from docker.types import CancellableStream
 
 from exegol.utils.ExeLog import logger
 
@@ -17,7 +13,7 @@ class ContainerLogStream:
         # Container to extract logs from
         self.__container = container
         # Fetch more logs from this datetime
-        self.__start_date: datetime = datetime.utcnow() if start_date is None else start_date
+        self.__start_date: datetime = datetime.now() if start_date is None else start_date
         self.__since_date = self.__start_date
         self.__until_date: Optional[datetime] = None
         # The data stream is returned from the docker SDK. It can contain multiple line at the same.
@@ -30,7 +26,7 @@ class ContainerLogStream:
 
         # Hint message flag
         self.__tips_sent = False
-        self.__tips_timedelta = self.__start_date + timedelta(seconds=15)
+        self.__tips_timedelta = self.__start_date + timedelta(seconds=30)
 
     def __iter__(self):
         return self
@@ -38,7 +34,7 @@ class ContainerLogStream:
     def __next__(self):
         """Get the next line of the stream"""
         if self.__until_date is None:
-            self.__until_date = datetime.utcnow()
+            self.__until_date = datetime.now()
         while True:
             # The data stream is fetch from the docker SDK once empty.
             if self.__data_stream is None:
@@ -69,4 +65,4 @@ class ContainerLogStream:
             self.__data_stream = None
             self.__since_date = self.__until_date
             time.sleep(0.5)  # Wait for more logs
-            self.__until_date = datetime.utcnow()
+            self.__until_date = datetime.now()

--- a/exegol/utils/DataFileUtils.py
+++ b/exegol/utils/DataFileUtils.py
@@ -1,4 +1,6 @@
 import json
+import os
+import sys
 from json import JSONEncoder, JSONDecodeError
 from pathlib import Path
 from typing import Union, Dict, cast, Optional, Set, Any
@@ -8,6 +10,7 @@ import yaml.parser
 
 from exegol.config.ConstantConfig import ConstantConfig
 from exegol.utils.ExeLog import logger
+from exegol.utils.FsUtils import mkdir, get_user_id
 
 
 class DataFileUtils:
@@ -47,7 +50,7 @@ class DataFileUtils:
         """
         if not self._file_path.parent.is_dir():
             logger.verbose(f"Creating config folder: {self._file_path.parent}")
-            self._file_path.parent.mkdir(parents=True, exist_ok=True)
+            mkdir(self._file_path.parent)
         if not self._file_path.is_file():
             logger.verbose(f"Creating default file: {self._file_path}")
             self._create_config_file()
@@ -72,6 +75,9 @@ class DataFileUtils:
         try:
             with open(self._file_path, 'w') as file:
                 file.write(self._build_file_content())
+            if sys.platform == "linux" and os.getuid() == 0:
+                user_uid, user_gid = get_user_id()
+                os.chown(self._file_path, user_uid, user_gid)
         except PermissionError as e:
             logger.critical(f"Unable to open the file '{self._file_path}' ({e}). Please fix your file permissions or run exegol with the correct rights.")
 

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -603,7 +603,7 @@ class DockerUtils(metaclass=MetaSingleton):
                                         tag=f"{ConstantConfig.IMAGE_NAME}:{tag}",
                                         buildargs={"TAG": f"{build_profile}",
                                                    "VERSION": "local",
-                                                   "BUILD_DATE": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')},
+                                                   "BUILD_DATE": datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')},
                                         platform="linux/" + ParametersManager().arch,
                                         rm=True,
                                         forcerm=True,

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -4,6 +4,7 @@ from time import sleep
 from typing import List, Optional, Union, cast
 
 import docker
+import requests.exceptions
 from docker import DockerClient
 from docker.errors import APIError, DockerException, NotFound, ImageNotFound
 from docker.models.images import Image
@@ -58,6 +59,8 @@ class DockerUtils(metaclass=MetaSingleton):
                 logger.critical(
                     "Unable to connect to docker (from env config). Is docker operational and accessible? on your machine? "
                     "Exiting.")
+        except (ReadTimeout, requests.exceptions.ConnectionError):
+            logger.critical("Docker daemon seems busy, Exegol receives timeout response. Try again later.")
         self.__images: Optional[List[ExegolImage]] = None
         self.__containers: Optional[List[ExegolContainer]] = None
 
@@ -556,9 +559,9 @@ class DockerUtils(metaclass=MetaSingleton):
         try:
             self.__client.images.remove(image_name, force=False, noprune=False)
             return True
-        except ReadTimeout:
+        except (ReadTimeout, requests.exceptions.ConnectionError):
             logger.warning("The deletion of the image has timeout. Docker is still processing the removal, please wait.")
-            max_retry = 5
+            max_retry = 10
             wait_time = 5
             for i in range(5):
                 try:
@@ -569,7 +572,7 @@ class DockerUtils(metaclass=MetaSingleton):
                         return True
                     else:
                         logger.debug(f"Unexpected error after timeout: {err}")
-                except ReadTimeout:
+                except (ReadTimeout, requests.exceptions.ConnectionError):
                     wait_time = wait_time + wait_time * i
                     logger.info(f"Docker timeout again ({i + 1}/{max_retry}). Next retry in {wait_time} seconds...")
                     sleep(wait_time)  # Wait x seconds before retry

--- a/exegol/utils/FsUtils.py
+++ b/exegol/utils/FsUtils.py
@@ -1,9 +1,11 @@
 import logging
+import os
 import re
 import stat
 import subprocess
+import sys
 from pathlib import Path, PurePath
-from typing import Optional
+from typing import Optional, Tuple
 
 from exegol.config.EnvInfo import EnvInfo
 from exegol.utils.ExeLog import logger
@@ -104,3 +106,33 @@ def check_sysctl_value(sysctl: str, compare_to: str) -> bool:
     except PermissionError:
         logger.debug(f"Unable to read sysctl {sysctl} permission!")
     return False
+
+
+def get_user_id() -> Tuple[int, int]:
+    user_uid_raw = os.getenv("SUDO_UID")
+    if user_uid_raw is None:
+        user_uid = os.getuid()
+    else:
+        user_uid = int(user_uid_raw)
+    user_gid_raw = os.getenv("SUDO_GID")
+    if user_gid_raw is None:
+        user_gid = os.getgid()
+    else:
+        user_gid = int(user_gid_raw)
+    return user_uid, user_gid
+
+
+def mkdir(path):
+    try:
+        path.mkdir(parents=False, exist_ok=False)
+        if sys.platform == "linux" and os.getuid() == 0:
+            user_uid, user_gid = get_user_id()
+            os.chown(path, user_uid, user_gid)
+    except FileExistsError:
+        # The directory already exist, this setup can be skipped
+        pass
+    except FileNotFoundError:
+        # Create parent directory first
+        mkdir(path.parent)
+        # Then create the targeted directory
+        mkdir(path)

--- a/exegol/utils/FsUtils.py
+++ b/exegol/utils/FsUtils.py
@@ -95,6 +95,7 @@ def setGidPermission(root_folder: Path):
 
 
 def check_sysctl_value(sysctl: str, compare_to: str) -> bool:
+    """Function to find a sysctl configured value and compare it to a desired value."""
     sysctl_path = "/proc/sys/" + sysctl.replace('.', '/')
     try:
         with open(sysctl_path, 'r') as conf:
@@ -109,6 +110,9 @@ def check_sysctl_value(sysctl: str, compare_to: str) -> bool:
 
 
 def get_user_id() -> Tuple[int, int]:
+    """On linux system, retrieve the original user id when using SUDO."""
+    if sys.platform == "win32":
+        raise SystemError
     user_uid_raw = os.getenv("SUDO_UID")
     if user_uid_raw is None:
         user_uid = os.getuid()
@@ -123,6 +127,7 @@ def get_user_id() -> Tuple[int, int]:
 
 
 def mkdir(path):
+    """Function to recursively create a directory and setting the right user and group id to allow host user access."""
     try:
         path.mkdir(parents=False, exist_ok=False)
         if sys.platform == "linux" and os.getuid() == 0:


### PR DESCRIPTION
# Exegol wrapper 4.3.7

## Features

New minor exegol version including:
- a new configuration to disable Exegol resources by default for any new container
- (BETA) X11 forwarding when using exegol on a linux server thanks to @Xenorf

## Bug fixes

- Fix waiting for `my-resources` to install at container creation before opening a shell
- Fix Exegol directories permission when using exegol with `sudo`
- Handle docker timeout exceptions
- Fix a log stream error from #233 
