### PR TITLE
Add certificate support for openvpn

### DIFF
--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -260,14 +260,14 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                                action="store",
                                help="Enter the credentials with a file (first line: username, second line: password) to establish the VPN connection automatically (example: --vpn-auth /home/user/vpn/auth.txt)")
 
-        self.vpn_cert = Option("--vpn-cert",
-                               dest="vpn_cert",
+        self.vpn_cert_path = Option("--vpn-cert",
+                               dest="vpn_cert_path",
                                default=None,
                                action="store",
                                help="Enter the certificate using the file that came with your config pack to establish the VPN connection automatically. Please remove any entries for the 'ca' option in your openvpn configuration file. (example: --vpn-cert /home/user/vpn/cert.crt)")
         groupArgs.append(GroupArg({"arg": self.vpn, "required": False},
                                   {"arg": self.vpn_auth, "required": False},
-                                  {"arg": self.vpn_cert, "required":False},
+                                  {"arg": self.vpn_cert_path, "required":False},
                                   title="[blue]Container creation VPN options[/blue]"))
 
         self.desktop = Option("--desktop",

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -264,7 +264,7 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                                dest="vpn_cert",
                                default=None,
                                action="store",
-                               help="Enter the certificate using the file that came with your config pack to establish the VPN connection automatically (example: --vpn-cert /home/user/vpn/cert.crt)")
+                               help="Enter the certificate using the file that came with your config pack to establish the VPN connection automatically. Please remove any entries for the 'ca' option in your openvpn configuration file. (example: --vpn-cert /home/user/vpn/cert.crt)")
         groupArgs.append(GroupArg({"arg": self.vpn, "required": False},
                                   {"arg": self.vpn_auth, "required": False},
                                   {"arg": self.vpn_cert, "required":False},

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -260,8 +260,14 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                                action="store",
                                help="Enter the credentials with a file (first line: username, second line: password) to establish the VPN connection automatically (example: --vpn-auth /home/user/vpn/auth.txt)")
 
+        self.vpn_cert = Option("--vpn-cert",
+                               dest="vpn_cert",
+                               default=None,
+                               action="store",
+                               help="Enter the certificate using the file that came with your config pack to establish the VPN connection automatically (example: --vpn-cert /home/user/vpn/cert.crt)")
         groupArgs.append(GroupArg({"arg": self.vpn, "required": False},
                                   {"arg": self.vpn_auth, "required": False},
+                                  {"arg": self.vpn_cert, "required":False},
                                   title="[blue]Container creation VPN options[/blue]"))
 
         self.desktop = Option("--desktop",

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -665,6 +665,7 @@ class ContainerConfig:
             self.removeDevice("/dev/net/tun")
             # Try to remove each possible volume
             self.removeVolume(container_path="/.exegol/vpn/auth/creds.txt")
+            self.removeVolume(container_path="/.exegol/vpn/auth/certificate.crt")
             self.removeVolume(container_path="/.exegol/vpn/config/client.ovpn")
             self.removeVolume(container_path="/.exegol/vpn/config")
             return True
@@ -692,6 +693,24 @@ class ContainerConfig:
         OVPN config file directly supplied or a config directory,
         the directory feature is useful when the configuration depends on multiple files like certificate, keys etc."""
         ovpn_parameters = []
+
+        # VPN certificate path
+
+        vpn_cert_path = ParametersManager().vpn_cert_path
+        vpn_cert = None
+
+        if vpn_cert_path is not None:
+            vpn_cert = Path(vpn_cert_path).expanduser()
+
+        if vpn_cert is not None:
+            if vpn_cert.is_file():
+                logger.info(f"Adding VPN certificate from: {str(vpn_cert.absolute())}")
+                self.addVolume(vpn_cert, "/.exegol/vpn/auth/certificate.crt", read_only=True)
+                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt")
+            else:
+                # Supply a directory instead of a file for a VPN certificate is not supported.
+                logger.critical(
+                    f"The path provided to the VPN connection certificate ({str(vpn_auth)}) does not lead to a file. Aborting operation.")
 
         # VPN config path
         vpn_path = Path(config_path if config_path else ParametersManager().vpn).expanduser()

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -694,24 +694,6 @@ class ContainerConfig:
         the directory feature is useful when the configuration depends on multiple files like certificate, keys etc."""
         ovpn_parameters = []
 
-        # VPN certificate path
-
-        vpn_cert_path = ParametersManager().vpn_cert_path
-        vpn_cert = None
-
-        if vpn_cert_path is not None:
-            vpn_cert = Path(vpn_cert_path).expanduser()
-
-        if vpn_cert is not None:
-            if vpn_cert.is_file():
-                logger.info(f"Adding VPN certificate from: {str(vpn_cert.absolute())}")
-                self.addVolume(vpn_cert, "/.exegol/vpn/auth/certificate.crt", read_only=True)
-                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt")
-            else:
-                # Supply a directory instead of a file for a VPN certificate is not supported.
-                logger.critical(
-                    f"The path provided to the VPN connection certificate ({str(vpn_auth)}) does not lead to a file. Aborting operation.")
-
         # VPN config path
         vpn_path = Path(config_path if config_path else ParametersManager().vpn).expanduser()
 
@@ -756,6 +738,24 @@ class ContainerConfig:
                 # Supply a directory instead of a file for VPN authentication is not supported.
                 logger.critical(
                     f"The path provided to the VPN connection credentials ({str(vpn_auth)}) does not lead to a file. Aborting operation.")
+
+         # VPN certificate path
+
+        vpn_cert_path = ParametersManager().vpn_cert_path
+        vpn_cert = None
+
+        if vpn_cert_path is not None:
+            vpn_cert = Path(vpn_cert_path).expanduser()
+
+        if vpn_cert is not None:
+            if vpn_cert.is_file():
+                logger.info(f"Adding VPN certificate from: {str(vpn_cert.absolute())}")
+                self.addVolume(vpn_cert, "/.exegol/vpn/auth/certificate.crt", read_only=True)
+                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt")
+            else:
+                # Supply a directory instead of a file for a VPN certificate is not supported.
+                logger.critical(
+                    f"The path provided to the VPN connection certificate ({str(vpn_auth)}) does not lead to a file. Aborting operation.")
 
         return ' '.join(ovpn_parameters)
 

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -706,8 +706,7 @@ class ContainerConfig:
             if vpn_cert.is_file():
                 logger.info(f"Adding VPN certificate from: {str(vpn_cert.absolute())}")
                 self.addVolume(vpn_cert, "/.exegol/vpn/auth/certificate.crt", read_only=True)
-                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt"
-
+                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt")
             else:
                 # Supply a directory instead of a file for a VPN certificate is not supported.
                 logger.critical(

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -706,7 +706,8 @@ class ContainerConfig:
             if vpn_cert.is_file():
                 logger.info(f"Adding VPN certificate from: {str(vpn_cert.absolute())}")
                 self.addVolume(vpn_cert, "/.exegol/vpn/auth/certificate.crt", read_only=True)
-                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt")
+                ovpn_parameters.append("--ca /.exegol/vpn/auth/certificate.crt"
+
             else:
                 # Supply a directory instead of a file for a VPN certificate is not supported.
                 logger.critical(


### PR DESCRIPTION
# Description

> This pull requests adds an additional option --vpn-cert when configuring a container with a vpn. This will append the --ca command to the ovpn cli allowing for a openvpn connection to be made with a certificate authority.

# Related issues

> I had to manually connect by putting the certificate into the container myself so I decided to make it easier for any of those in the future who have a certificate in their openvpn config pack.

# Point of attention

> I'm not sure if having ca option in config will overwrite --ca in cli command so I wrote a msg to remove it.
