### PR TITLE
feat: make image repository configurable

### DIFF
--- a/exegol/config/UserConfig.py
+++ b/exegol/config/UserConfig.py
@@ -31,6 +31,7 @@ class UserConfig(DataFileUtils, metaclass=MetaSingleton):
         self.desktop_default_enable: bool = False
         self.desktop_default_localhost: bool = True
         self.desktop_default_proto: str = "http"
+        self.image_name: str = ConstantConfig.IMAGE_NAME
 
         super().__init__("config.yml", "yml")
 
@@ -89,6 +90,8 @@ config:
         # Desktop service is exposed on localhost by default. If set to true, services will be exposed on localhost (127.0.0.1) otherwise it will be exposed on 0.0.0.0. This setting can be overwritten with --desktop-config
         localhost_by_default: {self.desktop_default_localhost}
 
+    # Image location on Docker Hub
+    image_name: {self.image_name}
 """
         return config
 
@@ -154,6 +157,7 @@ config:
             f"Desktop enabled by default: {boolFormatter(self.desktop_default_enable)}",
             f"Desktop default protocol: [blue]{self.desktop_default_proto}[/blue]",
             f"Desktop default host: [blue]{'localhost' if self.desktop_default_localhost else '0.0.0.0'}[/blue]",
+            f"Image default name: [blue]{self.image_name}[/blue]"
         ]
         # TUI can't be called from here to avoid circular importation
         return configs

--- a/exegol/config/UserConfig.py
+++ b/exegol/config/UserConfig.py
@@ -138,6 +138,9 @@ config:
         self.desktop_default_proto = self._load_config_str(desktop_data, 'default_protocol', self.desktop_default_proto, choices=self.desktop_available_proto)
         self.desktop_default_localhost = self._load_config_bool(desktop_data, 'localhost_by_default', self.desktop_default_localhost)
 
+        # Image selection
+        self.image_name = self._load_config_str(config_data, 'image_name', self.image_name)
+
     def get_configs(self) -> List[str]:
         """User configs getter each options"""
         configs = [

--- a/exegol/console/cli/actions/Command.py
+++ b/exegol/console/cli/actions/Command.py
@@ -2,8 +2,9 @@ import os
 from argparse import Namespace
 from typing import List, Optional, Tuple, Union, Dict, cast
 
-from exegol.console.ConsoleFormat import richLen
 from exegol.config.EnvInfo import EnvInfo
+from exegol.config.UserConfig import UserConfig
+from exegol.console.ConsoleFormat import richLen
 from exegol.utils.ExeLog import logger
 
 
@@ -90,6 +91,12 @@ class Command:
                                    dest="offline_mode",
                                    action="store_true",
                                    help=f"Run exegol in offline mode, no request will be made on internet (default: [red]Disable[/red])")
+        self.image_name = Option("--image-name",
+                                 dest="image_name",
+                                 metavar="IMAGE_NAME",
+                                 action="store",
+                                 default=UserConfig().image_name,
+                                 help="Image where exegol is stored.")
         # TODO review non-interactive mode
         # self.interactive_mode = Option("--non-interactive",
         #                               dest="interactive_mode",
@@ -105,6 +112,7 @@ class Command:
                      {"arg": self.verify, "required": False},
                      {"arg": self.offline_mode, "required": False},
                      {"arg": self.arch, "required": False},
+                     {"arg": self.image_name, "required": False},
                      title="[blue]Optional arguments[/blue]",
                      is_global=True)
         ]

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -1,3 +1,4 @@
+from exegol.config.UserConfig import UserConfig
 from exegol.console.cli.ExegolCompleter import HybridContainerImageCompleter, VoidCompleter, BuildProfileCompleter
 from exegol.console.cli.actions.Command import Command, Option, GroupArg
 from exegol.console.cli.actions.GenericParameters import ContainerCreation, ContainerSpawnShell, ContainerMultiSelector, ContainerSelector, ImageSelector, ImageMultiSelector, ContainerStart
@@ -96,6 +97,16 @@ class Install(Command, ImageSelector):
                                        {"arg": self.build_log, "required": False},
                                        {"arg": self.build_path, "required": False},
                                        title="[bold cyan]Build[/bold cyan] [blue]specific options[/blue]"))
+
+        # Create image selection arguments
+        self.image_name = Option("--image-name",
+                                 dest="image_name",
+                                 metavar="IMAGE_NAME",
+                                 action="store",
+                                 default=UserConfig().image_name,
+                                 help="Image where exegol is stored.")
+        self.groupArgs.append(GroupArg({"arg": self.image_name, "reuired": False},
+                                       title="[bold cyan]Image[/bold cyan] [blue]specific options[/blue]"))
 
         self._usages = {
             "Install or build interactively an exegol image": "exegol install",

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -1,4 +1,3 @@
-from exegol.config.UserConfig import UserConfig
 from exegol.console.cli.ExegolCompleter import HybridContainerImageCompleter, VoidCompleter, BuildProfileCompleter
 from exegol.console.cli.actions.Command import Command, Option, GroupArg
 from exegol.console.cli.actions.GenericParameters import ContainerCreation, ContainerSpawnShell, ContainerMultiSelector, ContainerSelector, ImageSelector, ImageMultiSelector, ContainerStart
@@ -97,16 +96,6 @@ class Install(Command, ImageSelector):
                                        {"arg": self.build_log, "required": False},
                                        {"arg": self.build_path, "required": False},
                                        title="[bold cyan]Build[/bold cyan] [blue]specific options[/blue]"))
-
-        # Create image selection arguments
-        self.image_name = Option("--image-name",
-                                 dest="image_name",
-                                 metavar="IMAGE_NAME",
-                                 action="store",
-                                 default=UserConfig().image_name,
-                                 help="Image where exegol is stored.")
-        self.groupArgs.append(GroupArg({"arg": self.image_name, "reuired": False},
-                                       title="[bold cyan]Image[/bold cyan] [blue]specific options[/blue]"))
 
         self._usages = {
             "Install or build interactively an exegol image": "exegol install",

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -98,7 +98,7 @@ class ExegolImage(SelectableInterface):
             self.__name = ""
             for repo_tag in self.__image.attrs["RepoTags"]:
                 repo, name = repo_tag.split(':')
-                if not repo.startswith(ConstantConfig.IMAGE_NAME):
+                if not repo.startswith(ParametersManager().image_name):
                     # Ignoring external images (set container using external image as outdated)
                     continue
                 version_parsed = MetaImages.tagNameParsing(name)
@@ -175,7 +175,7 @@ class ExegolImage(SelectableInterface):
         for repo_tag in docker_image.attrs["RepoTags"]:
             tmp_name, tmp_tag = repo_tag.split(':')
             version_parsed = MetaImages.tagNameParsing(tmp_tag)
-            if tmp_name == ConstantConfig.IMAGE_NAME and version_parsed:
+            if tmp_name == ParametersManager().image_name and version_parsed:
                 self.__setImageVersion(version_parsed)
         # backup plan: Use label to retrieve image version
         self.__labelVersionParsing()
@@ -541,7 +541,7 @@ class ExegolImage(SelectableInterface):
         """Parse the remote image digest ID.
         Return digest id from the docker object."""
         for digest_id in docker_image.attrs["RepoDigests"]:
-            if digest_id.startswith(ConstantConfig.IMAGE_NAME):  # Find digest id from the right repository
+            if digest_id.startswith(ParametersManager().image_name):  # Find digest id from the right repository
                 return digest_id.split('@')[1]
         return ""
 
@@ -678,11 +678,11 @@ class ExegolImage(SelectableInterface):
 
     def getFullName(self) -> str:
         """Dockerhub image's full name getter"""
-        return f"{ConstantConfig.IMAGE_NAME}:{self.__name}"
+        return f"{ParametersManager().image_name}:{self.__name}"
 
     def getFullVersionName(self) -> str:
         """Dockerhub image's full (installed) version name getter"""
-        return f"{ConstantConfig.IMAGE_NAME}:{self.getInstalledVersionName()}"
+        return f"{ParametersManager().image_name}:{self.getInstalledVersionName()}"
 
     def getDockerRef(self) -> str:
         """Find and return the right id to target the current image for docker.

--- a/exegol/utils/WebUtils.py
+++ b/exegol/utils/WebUtils.py
@@ -19,7 +19,7 @@ class WebUtils:
     @classmethod
     def __getGuestToken(cls, action: str = "pull", service: str = "registry.docker.io") -> Optional[str]:
         """Generate a guest token for Registry service"""
-        url = f"https://auth.docker.io/token?scope=repository:{ConstantConfig.IMAGE_NAME}:{action}&service={service}"
+        url = f"https://auth.docker.io/token?scope=repository:{ParametersManager().image_name}:{action}&service={service}"
         response = cls.runJsonRequest(url, service_name="Docker Auth")
         if response is not None:
             return response.get("access_token")
@@ -68,7 +68,7 @@ class WebUtils:
             return None
         manifest_headers = {"Accept": "application/vnd.docker.distribution.manifest.list.v2+json", "Authorization": f"Bearer {token}"}
         # Query Docker registry API on manifest endpoint using tag name
-        url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ConstantConfig.IMAGE_NAME}/manifests/{tag}"
+        url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ParametersManager().image_name}/manifests/{tag}"
         response = cls.__runRequest(url, service_name="Docker Registry", headers=manifest_headers, method="HEAD")
         digest_id: Optional[str] = None
         if response is not None:
@@ -89,7 +89,7 @@ class WebUtils:
         # In order to access the metadata of the image, the v1 manifest must be use
         manifest_headers = {"Accept": "application/vnd.docker.distribution.manifest.v1+json", "Authorization": f"Bearer {token}"}
         # Query Docker registry API on manifest endpoint using tag name
-        url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ConstantConfig.IMAGE_NAME}/manifests/{tag}"
+        url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ParametersManager().image_name}/manifests/{tag}"
         response = cls.__runRequest(url, service_name="Docker Registry", headers=manifest_headers, method="GET")
         version: Optional[str] = None
         if response is not None and response.status_code == 200:
@@ -114,7 +114,7 @@ class WebUtils:
                     first_digest = manifest[0].get("digest")
                     # Retrieve specific image detail from first image digest (architecture not sensitive)
                     manifest_headers["Accept"] = "application/vnd.docker.distribution.manifest.v2+json"
-                    url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ConstantConfig.IMAGE_NAME}/manifests/{first_digest}"
+                    url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ParametersManager().image_name}/manifests/{first_digest}"
                     response = cls.__runRequest(url, service_name="Docker Registry", headers=manifest_headers, method="GET")
                     if response is not None and response.status_code == 200:
                         data = json.loads(response.content.decode("utf-8"))
@@ -127,7 +127,7 @@ class WebUtils:
                 config_digest: Optional[str] = data.get("config", {}).get('digest')
                 if config_digest is not None:
                     manifest_headers["Accept"] = "application/json"
-                    url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ConstantConfig.IMAGE_NAME}/blobs/{config_digest}"
+                    url = f"https://{ConstantConfig.DOCKER_REGISTRY}/v2/{ParametersManager().image_name}/blobs/{config_digest}"
                     response = cls.__runRequest(url, service_name="Docker Registry", headers=manifest_headers, method="GET")
                     if response is not None and response.status_code == 200:
                         data = json.loads(response.content.decode("utf-8"))


### PR DESCRIPTION
# Description

This adds the command line option `--image-name` which allows to configure which repository on Docker Hub is used to pull images from.

# Related issues

Somewhat related to ThePorgs/Roadmap#5

# Point of attention

The image name is technically incorrect as it refers to a repository on a docker registry (e.g. nwodtuhs/exegol). I chose the name because it was already in the source code before.