### PR TITLE
feat(wrapper): add gpu support in containers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ GitPython~=3.1.43
 PyYAML>=6.0.2
 argcomplete~=3.5.0
 tzlocal~=5.2; platform_system != 'Linux'
+torch~=2.6.0
+numpy~=2.2.3


### PR DESCRIPTION
# Description

Add GPU support using the `torch` Python module and the `device_requests` (`--gpus` in CLI) Docker argument.  
To do this I implemented the `isGPUAvailable` function which checks for GPU availability and returns the appropriate value for Docker's `--gpus` argument. Finally, I added `docker_args["device_requests"]` to enable GPU support when creating a container.

# Point of attention

I've also imported the `numpy` Python module but it's not required.
I imported it because of a warning message that appears when creating a new container with Exegol.

```bash
No module named numpy...
```

It works fine even without `numpy`, the error is just displayed when the module is missing.
For now, I haven't figured out how to solve this properly.

I found a way to suppress the warning using warning filters, so it doesn't print the message. Let me know if you want me to implement it this way.

Here's an example:

```python
import warnings
warnings.filterwarnings("ignore", message="No module named numpy", category=ImportWarning)
```

---

![image](https://github.com/user-attachments/assets/4f0d339f-efa8-4480-ae42-5c4fdb3f3e57)