### PR TITLE
 Release 4.3.11

### DIFF
--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-__version__ = "4.3.10"
+__version__ = "4.3.11"
 
 
 class ConstantConfig:

--- a/exegol/config/DataCache.py
+++ b/exegol/config/DataCache.py
@@ -64,15 +64,17 @@ class DataCache(DataFileUtils, metaclass=MetaSingleton):
         for img in images:
             name = img.getName()
             version = img.getLatestVersion()
-            remoteid = img.getLatestRemoteId()
-            type = "local" if img.isLocal() else "remote"
-            logger.debug(f"└── {name} (version: {version})\t→ ({type}) {remoteid}")
+            if "N/A" in version:
+                continue
+            remote_id = img.getLatestRemoteId()
+            image_type = "local" if img.isLocal() else "remote"
+            logger.debug(f"└── {name} (version: {version})\t→ ({image_type}) {remote_id}")
             cache_images.append(
                 ImageCacheModel(
                     name,
                     version,
-                    remoteid,
-                    type
+                    remote_id,
+                    image_type
                 )
             )
         self.__cache_data.images = ImagesCacheModel(cache_images)

--- a/exegol/config/EnvInfo.py
+++ b/exegol/config/EnvInfo.py
@@ -121,7 +121,7 @@ class EnvInfo:
         session_type = os.getenv("XDG_SESSION_TYPE", "x11")
         if session_type == "wayland":
             return cls.DisplayServer.WAYLAND
-        elif session_type == "x11":
+        elif session_type in ["x11", "tty"]:  # When using SSH X11 forwarding, the session type is "tty" instead of the classic "x11"
             return cls.DisplayServer.X11
         else:
             # Should return an error

--- a/exegol/config/EnvInfo.py
+++ b/exegol/config/EnvInfo.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 from enum import Enum
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Optional, List, Dict
 
@@ -224,6 +225,8 @@ class EnvInfo:
                 except FileNotFoundError:
                     logger.warning(f"Docker Desktop configuration file not found: '{file_path}'")
                     return {}
+                except JSONDecodeError:
+                    logger.critical(f"The Docker Desktop configuration file '{file_path}' is not a valid JSON. Please fix your configuration file first.")
             if cls.__docker_desktop_resource_config is None:
                 logger.warning(f"Docker Desktop configuration couldn't be loaded.'")
             else:

--- a/exegol/config/EnvInfo.py
+++ b/exegol/config/EnvInfo.py
@@ -26,7 +26,7 @@ class EnvInfo:
 
     class DockerEngine(Enum):
         """Dictionary class for static Docker engine name"""
-        WLS2 = "WSL2"
+        WSL2 = "WSL2"
         HYPERV = "Hyper-V"
         DOCKER_DESKTOP = "Docker desktop"
         ORBSTACK = "Orbstack"
@@ -86,7 +86,7 @@ class EnvInfo:
         if is_host_windows:
             # Check docker engine with Windows host
             if "wsl2" in docker_kernel:
-                cls.__docker_engine = cls.DockerEngine.WLS2
+                cls.__docker_engine = cls.DockerEngine.WSL2
             else:
                 cls.__docker_engine = cls.DockerEngine.HYPERV
             cls.__docker_host_os = cls.HostOs.WINDOWS

--- a/exegol/console/cli/actions/Command.py
+++ b/exegol/console/cli/actions/Command.py
@@ -48,7 +48,7 @@ class Command:
         # Root command usages (can be overwritten by subclasses to display different use cases)
         self._pre_usages = "[underline]To see specific examples run:[/underline][italic] exegol [cyan]command[/cyan] -h[/italic]"
         self._usages = {
-            "Install (or build) (↓ ~25GB max)": "exegol install",
+            "Install (or build) an exegol image": "exegol install",
             "Open an exegol shell": "exegol start",
             "Show exegol images & containers": "exegol info",
             "Update an image": "exegol update",

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -1130,9 +1130,11 @@ class ContainerConfig:
 
     def getShellEnvs(self) -> List[str]:
         """Overriding envs when opening a shell"""
-        result = []
+        result = [f"{self.ExegolEnv.user_shell.value}={ParametersManager().shell}"]
         # Select default shell to use
-        result.append(f"{self.ExegolEnv.user_shell.value}={ParametersManager().shell}")
+        if ParametersManager().shell in ["zsh", "bash", "sh"]:
+            # tmux dynamically set SHELL variable and should be excluded here
+            result.append(f"SHELL=/bin/{ParametersManager().shell}")
         # Update X11 DISPLAY socket if needed
         if self.__enable_gui:
             current_display = GuiUtils.getDisplayEnv()

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -114,7 +114,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
 
     def __start_container(self) -> None:
         """
-        This method start the container and display startup status update to the user.
+        This method starts the container and displays startup status updates to the user.
         :return:
         """
         with console.status(f"Waiting to start {self.name}", spinner_style="blue") as progress:
@@ -123,7 +123,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                 self.__container.start()
             except APIError as e:
                 logger.debug(e)
-                logger.critical(f"Docker raise a critical error when starting the container [green]{self.name}[/green], error message is: {e.explanation}")
+                logger.critical(f"Docker raised a critical error when starting the container [green]{self.name}[/green], error message is: {e.explanation}")
             if not self.config.legacy_entrypoint:  # TODO improve startup compatibility check
                 try:
                     # Try to find log / startup messages. Will time out after 2 seconds if the image don't support status update through container logs.
@@ -131,18 +131,33 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                         # Once the last log "READY" is received, the startup sequence is over and the execution can continue
                         if line == "READY":
                             break
-                        elif line.startswith('[W]'):
-                            line = line.replace('[W]', '')
-                            logger.warning(line)
-                        elif line.startswith('[E]'):
-                            line = line.replace('[E]', '')
-                            logger.error(line)
-                        else:
+                        elif line.startswith('[INFO]'):
+                            line = line.replace('[INFO]', '')
+                            logger.info(line)
+                        elif line.startswith('[VERBOSE]'):
+                            line = line.replace('[VERBOSE]', '')
                             logger.verbose(line)
+                        elif line.startswith('[ADVANCED]'):
+                            line = line.replace('[ADVANCED]', '')
+                            logger.advanced(line)
+                        elif line.startswith('[DEBUG]'):
+                            line = line.replace('[DEBUG]', '')
+                            logger.debug(line)
+                        elif line.startswith('[WARNING]'):
+                            line = line.replace('[WARNING]', '')
+                            logger.warning(line)
+                        elif line.startswith('[ERROR]'):
+                            line = line.replace('[ERROR]', '')
+                            logger.error(line)
+                        elif line.startswith('[SUCCESS]'):
+                            line = line.replace('[SUCCESS]', '')
+                            logger.success(line)
+                        else:
+                            logger.debug(line)
                         progress.update(status=f"[blue][Startup][/blue] {line}")
                 except KeyboardInterrupt:
                     # User can cancel startup logging with ctrl+C
-                    logger.warning("User skip startup status updates. Spawning a shell now.")
+                    logger.warning("Skipping startup status updates (user interruption). Spawning shell now.")
 
     def stop(self, timeout: int = 10) -> None:
         """Stop the docker container"""

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -187,6 +187,9 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
             options += f" -e {' -e '.join(envs)}"
         cmd = f"docker exec{options} -ti {self.getFullId()} {self.config.getShellCommand()}"
         logger.debug(f"Opening shell with: {cmd}")
+        if EnvInfo.is_windows_shell:
+            # Disable "What's next?" Docker Desktop spam exit message
+            os.environ['DOCKER_CLI_HINTS'] = "false"
         os.system(cmd)
         # Docker SDK doesn't support (yet) stdin properly
         # result = self.__container.exec_run(ParametersManager().shell, stdout=True, stderr=True, stdin=True, tty=True,

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -158,6 +158,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                             progress.update(status=f"[blue][Startup][/blue] {line}")
                         else:
                             logger.debug(line)
+                    logger.verbose(f"Container started in {(datetime.now() - start_date).seconds} seconds")
 
                 except KeyboardInterrupt:
                     # User can cancel startup logging with ctrl+C

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -152,9 +152,13 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                         elif line.startswith('[SUCCESS]'):
                             line = line.replace('[SUCCESS]', '')
                             logger.success(line)
+                        elif line.startswith('[PROGRESS]'):
+                            line = line.replace('[PROGRESS]', '')
+                            logger.verbose(line)
+                            progress.update(status=f"[blue][Startup][/blue] {line}")
                         else:
                             logger.debug(line)
-                        progress.update(status=f"[blue][Startup][/blue] {line}")
+
                 except KeyboardInterrupt:
                     # User can cancel startup logging with ctrl+C
                     logger.warning("Skipping startup status updates (user interruption). Spawning shell now.")

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -187,7 +187,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
             options += f" -e {' -e '.join(envs)}"
         cmd = f"docker exec{options} -ti {self.getFullId()} {self.config.getShellCommand()}"
         logger.debug(f"Opening shell with: {cmd}")
-        if EnvInfo.is_windows_shell:
+        if EnvInfo.isDockerDesktop() and (EnvInfo.is_windows_shell or EnvInfo.is_mac_shell):
             # Disable "What's next?" Docker Desktop spam exit message
             os.environ['DOCKER_CLI_HINTS'] = "false"
         os.system(cmd)

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -161,7 +161,7 @@ class DockerUtils(metaclass=MetaSingleton):
             # Not reachable, critical logging will exit
             return  # type: ignore
         if container is not None:
-            logger.success("Exegol container successfully created !")
+            logger.success("Exegol container successfully created!")
         else:
             logger.critical("Unknown error while creating exegol container. Exiting.")
             # Not reachable, critical logging will exit

--- a/exegol/utils/GuiUtils.py
+++ b/exegol/utils/GuiUtils.py
@@ -216,7 +216,7 @@ class GuiUtils:
             return False
         logger.debug("WSL is [green]available[/green] on the local system")
         # Only WSL2 support WSLg
-        if EnvInfo.getDockerEngine() != EnvInfo.DockerEngine.WLS2:
+        if EnvInfo.getDockerEngine() != EnvInfo.DockerEngine.WSL2:
             logger.debug(f"Docker current engine: {EnvInfo.getDockerEngine().value}")
             logger.error("Docker must be run with [orange3]WSL2[/orange3] engine in order to support X11 sharing (i.e. GUI apps).")
             return False

--- a/exegol/utils/imgsync/entrypoint.sh
+++ b/exegol/utils/imgsync/entrypoint.sh
@@ -19,7 +19,6 @@ function load_setups() {
       echo "[PROGRESS]Starting [green]my-resources[/green] setup"
       /.exegol/load_supported_setups.sh | grep --line-buffered '^\[EXEGOL]' | sed -u "s/^\[EXEGOL\]\s*//g"
     else
-      echo "[VERBOSE]My-resources setup not found in /.exegol/load_supported_setups.sh"
       echo "[WARNING]Your exegol image doesn't support my-resources custom setup!"
     fi
   fi

--- a/exegol/utils/imgsync/entrypoint.sh
+++ b/exegol/utils/imgsync/entrypoint.sh
@@ -68,7 +68,7 @@ function _resolv_docker_host() {
     # Add docker internal host resolution to the hosts file to preserve access to the X server
     echo "$DOCKER_IP        host.docker.internal" >>/etc/hosts
     # If the container share the host networks, no need to add a static mapping
-    ip route list match "$DOCKER_IP" table all | grep -v default || ip route add "$DOCKER_IP/32" "$(ip route list | grep default | head -n1 | grep -Eo '(via [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ )?dev [a-zA-Z0-9]+')" || echo '[W]Exegol cannot add a static route to resolv your host X11 server. GUI applications may not work.'
+    ip route list match "$DOCKER_IP" table all | grep -v default || ip route add "$DOCKER_IP/32" "$(ip route list | grep default | head -n1 | grep -Eo '(via [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ )?dev [a-zA-Z0-9]+')" || echo '[WARNING]Exegol cannot add a static route to resolv your host X11 server. GUI applications may not work.'
   fi
 }
 

--- a/exegol/utils/imgsync/entrypoint.sh
+++ b/exegol/utils/imgsync/entrypoint.sh
@@ -8,18 +8,19 @@ function exegol_init() {
 
 # Function specific
 function load_setups() {
+  # Logs are using [INFO], [VERBOSE], [WARNING], [ERROR], [SUCCESS] tags so that the wrapper can catch them and forward them to the user with the corresponding logger level
   # Load custom setups (supported setups, and user setup)
   [[ -d "/var/log/exegol" ]] || mkdir -p /var/log/exegol
   if [[ ! -f "/.exegol/.setup.lock" ]]; then
     # Execute initial setup if lock file doesn't exist
     echo >/.exegol/.setup.lock
-    # Run my-resources script. Logs starting with '[exegol]' will be print to the console and report back to the user through the wrapper.
+    # Run my-resources script. Logs starting with '[EXEGOL]' will be printed to the console and reported back to the user through the wrapper.
     if [ -f /.exegol/load_supported_setups.sh ]; then
-      echo "Installing [green]my-resources[/green] custom setup ..."
-      /.exegol/load_supported_setups.sh |& tee /var/log/exegol/load_setups.log | grep -i '^\[exegol]' | sed "s/^\[exegol\]\s*//gi"
-      [ -f /var/log/exegol/load_setups.log ] && echo "Compressing [green]my-resources[/green] logs" && gzip /var/log/exegol/load_setups.log && echo "My-resources loaded"
+      echo "[VERBOSE]Starting my-resources setup"
+      /.exegol/load_supported_setups.sh |& tee /var/log/exegol/load_setups.log | grep '^\[EXEGOL]' | sed "s/^\[EXEGOL\]\s*//g"
     else
-      echo "[W]Your exegol image doesn't support my-resources custom setup!"
+      echo "[VERBOSE]My-resources setup not found in /.exegol/load_supported_setups.sh"
+      echo "[WARNING]Your exegol image doesn't support my-resources custom setup!"
     fi
   fi
 }

--- a/exegol/utils/imgsync/entrypoint.sh
+++ b/exegol/utils/imgsync/entrypoint.sh
@@ -80,7 +80,8 @@ function ovpn() {
   else
     # Starting openvpn as a job with '&' to be able to receive SIGTERM signal and close everything properly
     echo "[PROGRESS]Starting [green]VPN[/green]"
-    openvpn --log-append /var/log/exegol/vpn.log "$@" &
+    # shellcheck disable=SC2164
+    ([[ -d /.exegol/vpn/config ]] && cd /.exegol/vpn/config; openvpn --log-append /var/log/exegol/vpn.log "$@" &)
     sleep 2  # Waiting 2 seconds for the VPN to start before continuing
   fi
 


### PR DESCRIPTION
# Exegol wrapper 4.3.11

## Features

- Improve my-resources loading time and logs
- Configure `$SHELL` variable for interactive sessions
- Disable Docker Desktop tips when using Exegol from Windows

## Bug fixes

- Fix X11 forwarding via SSH #237
- OpenVPN with multiple file can now use relative path