### PR TITLE
 Release 4.3.12

### DIFF
--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-__version__ = "4.3.11"
+__version__ = "4.3.12"
 
 
 class ConstantConfig:

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -133,6 +133,7 @@ class DockerUtils(metaclass=MetaSingleton):
                        "stdin_open": model.config.interactive,
                        "tty": model.config.tty,
                        "mounts": model.config.getVolumes(),
+                       "userns_mode": "host",
                        "working_dir": model.config.getWorkingDir()}
         if temporary:
             # Only the 'run' function support the "remove" parameter


### PR DESCRIPTION
# Exegol wrapper 4.3.11

## Bug fixes
Exegol now support userns remap.
