### PR TITLE
feat(wrapper): Add zellij (terminal multiplexer like tmux)

### DIFF
--- a/exegol/config/UserConfig.py
+++ b/exegol/config/UserConfig.py
@@ -11,7 +11,7 @@ class UserConfig(DataFileUtils, metaclass=MetaSingleton):
     """This class allows loading user defined configurations"""
 
     # Static choices
-    start_shell_options = {'zsh', 'bash', 'tmux'}
+    start_shell_options = {'zsh', 'bash', 'tmux', 'zellij'}
     shell_logging_method_options = {'script', 'asciinema'}
     desktop_available_proto = {'http', 'vnc'}
 

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -22,7 +22,7 @@ class Start(Command, ContainerCreation, ContainerSpawnShell):
             "Create a container [blue]htb[/blue] with a VPN": "exegol start [blue]htb[/blue] [bright_blue]full[/bright_blue] --vpn [magenta]~/vpn/[/magenta][bright_magenta]lab_Dramelac.ovpn[/bright_magenta]",
             "Create a container [blue]app[/blue] with custom volume": "exegol start [blue]app[/blue] [bright_blue]full[/bright_blue] -V [bright_magenta]/var/app/[/bright_magenta]:[bright_magenta]/app/[/bright_magenta]",
             "Create a container [blue]app[/blue] with custom volume in [blue]ReadOnly[/blue]": "exegol start [blue]app[/blue] [bright_blue]full[/bright_blue] -V [bright_magenta]/var/app/[/bright_magenta]:[bright_magenta]/app/[/bright_magenta]:[blue]ro[/blue]",
-            "Get a [blue]tmux[/blue] shell": "exegol start --shell [blue]tmux[/blue]",
+            "Get a [blue]tmux[/blue] or [blue]zellij[/blue] shell": "exegol start --shell [blue]tmux[/blue]",
             "Share a specific [blue]hardware device[/blue] [bright_black](e.g. Proxmark)[/bright_black]": "exegol start -d /dev/ttyACM0",
             "Share every [blue]USB device[/blue] connected to the host": "exegol start -d /dev/bus/usb/",
         }


### PR DESCRIPTION
# Description

This adds the `zellij` command line option `--shell` which allows to select this new terminal multiplexer shell environment at startup

Works with wrapper and desktop mode:
[![](https://asciinema.org/a/DyF9gVTwReYI7H76aVf89GbjY.svg.svg)](https://asciinema.org/a/DyF9gVTwReYI7H76aVf89GbjY.svg?autoplay=1)

[](https://github.com/user-attachments/assets/d62a5059-2163-46f3-978b-3219d8dc40e0)








