### PR TITLE
feat: container storage usage in `exegol info`

### DIFF
--- a/exegol/console/ConsoleFormat.py
+++ b/exegol/console/ConsoleFormat.py
@@ -56,3 +56,20 @@ def parse_date(date: str) -> datetime:
         # Handle date parsing for python before 3.11
         from dateutil.parser import isoparse
         return isoparse(date)
+
+
+def process_size(size: Union[int, float], precision: int = 1, compression_factor: float = 1) -> str:
+    """Text formatter from size number to human-readable size."""
+    if size == 0:
+        return "0 B"
+    #if size < 100:
+    #    # Size is supplied in GB
+    #    return f"{size} GB"
+    # https://stackoverflow.com/a/32009595
+    suffixes = ["B", "KB", "MB", "GB", "TB"]
+    suffix_index = 0
+    calc: float = size * compression_factor
+    while calc > 1000 and suffix_index < 4:
+        suffix_index += 1  # increment the index of the suffix
+        calc = calc / 1000  # apply the division
+    return "%.*f %s" % (precision, calc, suffixes[suffix_index])

--- a/exegol/console/ConsoleFormat.py
+++ b/exegol/console/ConsoleFormat.py
@@ -57,7 +57,7 @@ def parse_date(date: str) -> datetime:
         from dateutil.parser import isoparse
         return isoparse(date)
 
-      
+
 def process_size(size: Union[int, float], precision: int = 1, compression_factor: float = 1) -> str:
     """Text formatter from size number to human-readable size."""
     if size == 0:

--- a/exegol/console/TUI.py
+++ b/exegol/console/TUI.py
@@ -233,6 +233,7 @@ class ExegolTUI:
         table.add_column("Container tag")
         table.add_column("State")
         table.add_column("Image tag")
+        table.add_column("Storage")
         table.add_column("Configurations")
         if verbose_mode:
             table.add_column("Mounts")
@@ -243,6 +244,7 @@ class ExegolTUI:
         for container in data:
             if verbose_mode:
                 table.add_row(container.getId(), container.getDisplayName(), container.getTextStatus(), container.image.getDisplayName(),
+                              container.getContainerStorageSize(),
                               container.config.getTextFeatures(verbose_mode),
                               container.config.getTextMounts(debug_mode),
                               container.config.getTextDevices(debug_mode),
@@ -250,6 +252,7 @@ class ExegolTUI:
                               container.config.getTextEnvs(debug_mode))
             else:
                 table.add_row(container.getDisplayName(), container.getTextStatus(), container.image.getDisplayName(),
+                              container.getContainerStorageSize(),
                               container.config.getTextFeatures(verbose_mode))
 
     @staticmethod

--- a/exegol/console/TUI.py
+++ b/exegol/console/TUI.py
@@ -244,7 +244,7 @@ class ExegolTUI:
         for container in data:
             if verbose_mode:
                 table.add_row(container.getId(), container.getDisplayName(), container.getTextStatus(), container.image.getDisplayName(),
-                              container.getContainerStorageSize(),
+                              container.getContainerStorageSize(verbose=True),
                               container.config.getTextFeatures(verbose_mode),
                               container.config.getTextMounts(debug_mode),
                               container.config.getTextDevices(debug_mode),
@@ -252,7 +252,7 @@ class ExegolTUI:
                               container.config.getTextEnvs(debug_mode))
             else:
                 table.add_row(container.getDisplayName(), container.getTextStatus(), container.image.getDisplayName(),
-                              container.getContainerStorageSize(),
+                              container.getContainerStorageSize(verbose=False),
                               container.config.getTextFeatures(verbose_mode))
 
     @staticmethod

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -13,6 +13,7 @@ from docker.errors import NotFound, ImageNotFound, APIError
 from docker.models.containers import Container
 
 from exegol.config.EnvInfo import EnvInfo
+from exegol.console import ConsoleFormat
 from exegol.console.ExegolPrompt import ExegolRich
 from exegol.console.ExegolStatus import ExegolStatus
 from exegol.console.cli.ParametersManager import ParametersManager
@@ -41,6 +42,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         logger.debug(f"Loading container: {docker_container.name}")
         self.__container: Container = docker_container
         self.__id: str = docker_container.id
+        self.__container_size: Optional[int] = docker_container.attrs.get('SizeRw')
         self.__xhost_applied = False
         self.__post_start_applied = False
         if model is None:
@@ -132,42 +134,34 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         In normal mode, returns total size. In verbose mode, returns tree breakdown.
         This excludes the base image size which is shared across containers."""
         try:
-            from exegol.utils.DockerUtils import DockerUtils
-            from exegol.model.ExegolImage import ExegolImage
-            
-            client = DockerUtils()._DockerUtils__client
-            # Use low-level containers API with size=True
-            containers_data = client.api.containers(all=True, filters={"id": self.__id}, size=True)
-            size_rw = containers_data[0].get('SizeRw', 0) if containers_data else 0
-            
             # Get workspace size in bytes
-            workspace_size = self.__getWorkspaceSize(return_bytes=True)
-            
+            workspace_size = self.__getWorkspaceSize()
+
+            size_rw = self.__container_size if self.__container_size is not None else 0
+
             # Calculate total
             total_size = size_rw + workspace_size
-            
+
             if verbose and (size_rw > 0 or workspace_size > 0):
                 # Verbose mode: show breakdown
-                container_str = ExegolImage._ExegolImage__processSize(size_rw) if size_rw > 0 else "0 B"
-                workspace_str = ExegolImage._ExegolImage__processSize(workspace_size) if workspace_size > 0 else "0 B"
-                return f"Container: {container_str}\nWorkspace: {workspace_str}"
-            
+                container_str = ConsoleFormat.process_size(size_rw)
+                workspace_str = ConsoleFormat.process_size(workspace_size)
+                return f"Container: {container_str}{os.linesep}Workspace: {workspace_str}"
+
             # Normal mode: show total only
-            if total_size == 0:
-                return "[bright_black]0 B[/bright_black]"
-            return ExegolImage._ExegolImage__processSize(total_size)
+            return ConsoleFormat.process_size(total_size)
         except Exception as e:
             logger.debug(f"Failed to get container storage size for {self.name}: {e}")
             return "[bright_black]N/A[/bright_black]"
-    
-    def __getWorkspaceSize(self, return_bytes: bool = False) -> Union[str, int]:
+
+    def __getWorkspaceSize(self) -> int:
         """Calculate workspace directory size.
-        If return_bytes=True, returns size as int. Otherwise returns formatted string."""
+        returns size as int"""
         try:
             workspace_path = self.config.getHostWorkspacePath()
             if not workspace_path or not os.path.exists(workspace_path):
-                return 0 if return_bytes else ""
-            
+                return 0
+
             # Use os.walk for efficiency (followlinks=False to avoid symlink issues)
             total_size = 0
             for dirpath, dirnames, filenames in os.walk(workspace_path, followlinks=False):
@@ -178,18 +172,11 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                     except (OSError, FileNotFoundError):
                         # Skip files we can't read or that disappeared
                         continue
-            
-            if return_bytes:
-                return total_size
-            
-            if total_size == 0:
-                return ""
-            
-            from exegol.model.ExegolImage import ExegolImage
-            return ExegolImage._ExegolImage__processSize(total_size)
+
+            return total_size
         except Exception as e:
             logger.debug(f"Failed to get workspace size for {self.name}: {e}")
-            return 0 if return_bytes else ""
+            return 0
 
     def getKey(self) -> str:
         """Universal unique key getter (from SelectableInterface)"""

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -127,27 +127,69 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         """Container's short id getter"""
         return self.__container.short_id
 
-    def getContainerStorageSize(self) -> str:
-        """Get the size of the container's writable layer (storage overhead).
+    def getContainerStorageSize(self, verbose: bool = False) -> str:
+        """Get the size of the container's writable layer and workspace.
+        In normal mode, returns total size. In verbose mode, returns tree breakdown.
         This excludes the base image size which is shared across containers."""
         try:
             from exegol.utils.DockerUtils import DockerUtils
+            from exegol.model.ExegolImage import ExegolImage
+            
             client = DockerUtils()._DockerUtils__client
             # Use low-level containers API with size=True
             containers_data = client.api.containers(all=True, filters={"id": self.__id}, size=True)
-            if containers_data:
-                size_rw = containers_data[0].get('SizeRw', 0)
-            else:
-                size_rw = 0
+            size_rw = containers_data[0].get('SizeRw', 0) if containers_data else 0
             
-            if size_rw == 0:
+            # Get workspace size in bytes
+            workspace_size = self.__getWorkspaceSize(return_bytes=True)
+            
+            # Calculate total
+            total_size = size_rw + workspace_size
+            
+            if verbose and (size_rw > 0 or workspace_size > 0):
+                # Verbose mode: show breakdown
+                container_str = ExegolImage._ExegolImage__processSize(size_rw) if size_rw > 0 else "0 B"
+                workspace_str = ExegolImage._ExegolImage__processSize(workspace_size) if workspace_size > 0 else "0 B"
+                return f"Container: {container_str}\nWorkspace: {workspace_str}"
+            
+            # Normal mode: show total only
+            if total_size == 0:
                 return "[bright_black]0 B[/bright_black]"
-            # Reuse the existing size formatting method from ExegolImage
-            from exegol.model.ExegolImage import ExegolImage
-            return ExegolImage._ExegolImage__processSize(size_rw)
+            return ExegolImage._ExegolImage__processSize(total_size)
         except Exception as e:
             logger.debug(f"Failed to get container storage size for {self.name}: {e}")
             return "[bright_black]N/A[/bright_black]"
+    
+    def __getWorkspaceSize(self, return_bytes: bool = False) -> Union[str, int]:
+        """Calculate workspace directory size.
+        If return_bytes=True, returns size as int. Otherwise returns formatted string."""
+        try:
+            workspace_path = self.config.getHostWorkspacePath()
+            if not workspace_path or not os.path.exists(workspace_path):
+                return 0 if return_bytes else ""
+            
+            # Use os.walk for efficiency (followlinks=False to avoid symlink issues)
+            total_size = 0
+            for dirpath, dirnames, filenames in os.walk(workspace_path, followlinks=False):
+                for filename in filenames:
+                    filepath = os.path.join(dirpath, filename)
+                    try:
+                        total_size += os.path.getsize(filepath)
+                    except (OSError, FileNotFoundError):
+                        # Skip files we can't read or that disappeared
+                        continue
+            
+            if return_bytes:
+                return total_size
+            
+            if total_size == 0:
+                return ""
+            
+            from exegol.model.ExegolImage import ExegolImage
+            return ExegolImage._ExegolImage__processSize(total_size)
+        except Exception as e:
+            logger.debug(f"Failed to get workspace size for {self.name}: {e}")
+            return 0 if return_bytes else ""
 
     def getKey(self) -> str:
         """Universal unique key getter (from SelectableInterface)"""

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -127,6 +127,28 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         """Container's short id getter"""
         return self.__container.short_id
 
+    def getContainerStorageSize(self) -> str:
+        """Get the size of the container's writable layer (storage overhead).
+        This excludes the base image size which is shared across containers."""
+        try:
+            from exegol.utils.DockerUtils import DockerUtils
+            client = DockerUtils()._DockerUtils__client
+            # Use low-level containers API with size=True
+            containers_data = client.api.containers(all=True, filters={"id": self.__id}, size=True)
+            if containers_data:
+                size_rw = containers_data[0].get('SizeRw', 0)
+            else:
+                size_rw = 0
+            
+            if size_rw == 0:
+                return "[bright_black]0 B[/bright_black]"
+            # Reuse the existing size formatting method from ExegolImage
+            from exegol.model.ExegolImage import ExegolImage
+            return ExegolImage._ExegolImage__processSize(size_rw)
+        except Exception as e:
+            logger.debug(f"Failed to get container storage size for {self.name}: {e}")
+            return "[bright_black]N/A[/bright_black]"
+
     def getKey(self) -> str:
         """Universal unique key getter (from SelectableInterface)"""
         return self.name

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -96,8 +96,8 @@ class ExegolImage(SelectableInterface):
                 self.__build_date = meta_img.build_date
                 self.__setArch(meta_img.arch)
                 if meta_img.download_size is not None:
-                    self.__dl_size = self.__processSize(meta_img.download_size)
-                self.__disk_size = self.__processSize(meta_img.disk_size)
+                    self.__dl_size = ConsoleFormat.process_size(meta_img.download_size)
+                self.__disk_size = ConsoleFormat.process_size(meta_img.disk_size)
                 self.__setDigest(meta_img.repo_digest)
                 self.__setLatestRemoteId(meta_img.repo_digest)  # Meta id is always the latest one
         # Debug every Exegol image init
@@ -237,9 +237,9 @@ class ExegolImage(SelectableInterface):
             self.__name = meta.tag
             self.__outdated = self.__version_specific
         if meta.download_size is not None:
-            self.__dl_size = self.__processSize(meta.download_size)
+            self.__dl_size = ConsoleFormat.process_size(meta.download_size)
         if not self.__dl_size:
-            self.__disk_size = self.__processSize(meta.disk_size)
+            self.__disk_size = ConsoleFormat.process_size(meta.disk_size)
         if not self.__build_date:
             self.__build_date = meta.build_date
         self.__setLatestVersion(meta.version)
@@ -523,21 +523,6 @@ class ExegolImage(SelectableInterface):
         result.extend(images)  # Adding left images
         return result
 
-    @staticmethod
-    def __processSize(size: Union[int, float], precision: int = 1, compression_factor: float = 1) -> str:
-        """Text formatter from size number to human-readable size."""
-        if size < 1000:
-            # Size is supplied in GB
-            return f"{size} GB"
-        # https://stackoverflow.com/a/32009595
-        suffixes = ["B", "KB", "MB", "GB", "TB"]
-        suffix_index = 0
-        calc: float = size * compression_factor
-        while calc > 1024 and suffix_index < 4:
-            suffix_index += 1  # increment the index of the suffix
-            calc = calc / 1024  # apply the division
-        return "%.*f %s" % (precision, calc, suffixes[suffix_index])
-
     def __eq__(self, other) -> bool:
         """Operation == overloading for ExegolImage object"""
         # How to compare two ExegolImage
@@ -658,7 +643,7 @@ class ExegolImage(SelectableInterface):
 
     def __setRealSize(self, value: int) -> None:
         """On-Disk image size setter"""
-        self.__disk_size = self.__processSize(value)
+        self.__disk_size = ConsoleFormat.process_size(value)
 
     def getRealSize(self) -> str:
         """Image size getter. If the image is installed, return the on-disk size, otherwise return the remote size"""

--- a/exegol/model/ExegolImage.py
+++ b/exegol/model/ExegolImage.py
@@ -100,8 +100,8 @@ class ExegolImage(SelectableInterface):
                 self.__build_date = meta_img.build_date
                 self.__setArch(meta_img.arch)
                 if meta_img.download_size is not None:
-                    self.__image_packed_size = ConsoleFormat.processSize(meta_img.download_size)
-                self.__image_unpacked_size = ConsoleFormat.processSize(meta_img.disk_size)
+                    self.__image_packed_size = ConsoleFormat.process_size(meta_img.download_size)
+                self.__image_unpacked_size = ConsoleFormat.process_size(meta_img.disk_size)
                 self.__setDigest(meta_img.repo_digest)
                 self.__setLatestRemoteId(meta_img.repo_digest)  # Meta id is always the latest one
         # Debug every Exegol image init
@@ -253,9 +253,9 @@ class ExegolImage(SelectableInterface):
             self.__name = meta.tag
             self.__outdated = self.__version_specific
         if meta.download_size is not None:
-            self.__image_packed_size = ConsoleFormat.processSize(meta.download_size)
+            self.__image_packed_size = ConsoleFormat.process_size(meta.download_size)
         if not self.__image_packed_size:
-            self.__image_unpacked_size = ConsoleFormat.processSize(meta.disk_size)
+            self.__image_unpacked_size = ConsoleFormat.process_size(meta.disk_size)
         if not self.__build_date:
             self.__build_date = meta.build_date
         self.__setLatestVersion(meta.version)
@@ -661,11 +661,11 @@ class ExegolImage(SelectableInterface):
 
     def __setUnpackedSize(self, value: int) -> None:
         """Unpacked image size setter"""
-        self.__image_unpacked_size = ConsoleFormat.processSize(value)
+        self.__image_unpacked_size = ConsoleFormat.process_size(value)
 
     def __setDiskUsage(self, value: int) -> None:
         """Disk usage size setter"""
-        self.__disk_usage = ConsoleFormat.processSize(value)
+        self.__disk_usage = ConsoleFormat.process_size(value)
 
     def __formatImageSize(self) -> str:
         """Add the on-disk usage to the image size when available."""

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -7,6 +7,7 @@ import docker
 import requests.exceptions
 from docker import DockerClient
 from docker.errors import APIError, DockerException, NotFound, ImageNotFound
+from docker.models.containers import Container
 from docker.models.images import Image
 from docker.models.networks import Network
 from docker.models.volumes import Volume
@@ -83,6 +84,24 @@ class DockerUtils(metaclass=MetaSingleton):
 
     # # # Container Section # # #
 
+    def __list_api_container(self, name: str, sparse: bool = False) -> List[Container]:
+        docker_containers = self.__client.api.containers(all=True, size=True, filters={"name": name, "label": f"{ExegolImage.Labels.app.value}=Exegol"})
+        containers = []
+        if docker_containers is not None:
+            for container in docker_containers:
+                if sparse:
+                    if len(container.get("Names", [])) > 0:
+                        container["Name"] = container["Names"][0]
+                    containers.append(self.__client.containers.prepare_model(container))
+                    continue
+                # Inspect the container for full information
+                full_container = self.__client.containers.get(container["Id"])
+                # Add missing info from the inspect action
+                full_container.attrs["SizeRw"] = container.get("SizeRw")
+                full_container.attrs["SizeRootFs"] = container.get("SizeRootFs")
+                containers.append(full_container)
+        return containers
+
     async def listContainers(self) -> List[ExegolContainer]:
         """List available docker containers.
         Return a list of ExegolContainer"""
@@ -90,7 +109,7 @@ class DockerUtils(metaclass=MetaSingleton):
             logger.verbose("Loading Exegol containers")
             self.__containers = []
             try:
-                docker_containers = self.__client.containers.list(all=True, filters={"name": "exegol-", "label": f"{ExegolImage.Labels.app.value}=Exegol"})
+                docker_containers = self.__list_api_container("exegol-")
             except APIError as err:
                 logger.debug(err)
                 logger.critical(err.explanation)
@@ -177,14 +196,13 @@ class DockerUtils(metaclass=MetaSingleton):
             logger.debug(err)
             model.rollback()
             try:
-                container = self.__client.containers.list(all=True, filters={"name": model.getContainerName(), "label": f"{ExegolImage.Labels.app.value}=Exegol"})
-                if container is not None and len(container) > 0:
-                    for c in container:
-                        if c.name == model.getContainerName():  # Search for exact match
-                            container[0].remove()
-                            logger.debug("Container removed")
+                container = self.__list_api_container(model.getContainerName(), sparse=True)
+                for c in container:
+                    if c.name == model.getContainerName():  # Search for exact match
+                        c.remove()
+                        logger.debug("Container removed")
             except APIError as e:
-                logger.debug(f"Error while removing dcontainer: {e}")
+                logger.debug(f"Error while removing container: {e}")
             try:
                 if docker_args.get("network") is not None and self.removeNetwork(cast(str, docker_args["network"])):
                     logger.debug("Network removed")
@@ -203,14 +221,14 @@ class DockerUtils(metaclass=MetaSingleton):
         """Get an ExegolContainer from tag name."""
         try:
             # Fetch potential container match from DockerSDK
-            container = self.__client.containers.list(all=True, filters={"name": f"exegol-{tag}", "label": f"{ExegolImage.Labels.app.value}=Exegol"})
+            container = self.__list_api_container(f"exegol-{tag}")
         except APIError as err:
             logger.debug(err)
             logger.critical(err.explanation)
             # Not reachable, critical logging will exit
             return  # type: ignore
         # Check if there is at least 1 result. If no container was found, raise ObjectNotFound.
-        if container is None or len(container) == 0:
+        if len(container) == 0:
             # Handle case-insensitive OS
             if EnvInfo.isWindowsHost() or EnvInfo.isMacHost():
                 # First try to fetch the container as-is (for retroactive support with old container with uppercase characters)


### PR DESCRIPTION
# Add container storage size display to `exegol info`

Adds a "Storage" column displaying each container's disk usage, excluding the shared base image layers.

## Display Modes

**Normal mode:** Shows total size (container + workspace)
<img width="1099" height="332" alt="image" src="https://github.com/user-attachments/assets/63bf2801-9cd2-4c4c-b05d-220d58cafc4f" />

**Verbose mode (-v):** Shows breakdown
<img width="1107" height="713" alt="image" src="https://github.com/user-attachments/assets/fe9383ce-b82f-44ed-b45b-d7c148346281" />

## Implementation

- Uses Docker API `containers(size=True)` to fetch `SizeRw` (container writable layer)
- Calculates workspace size via `os.walk()` with symlink safety (`followlinks=False`)
- Formats sizes using existing `ExegolImage.__processSize()` helper
- Base image layers are shared across containers (0 MB duplication per container)

## Technical Details

- **Container size:** Changes made on top of the base image (configs, cache, logs, etc.)
- **Workspace size:** Files in mounted `/workspace` directory
- **Total displayed:** Sum of both in normal mode, breakdown in verbose mode
