### PR TITLE
Add CDI device selector and Nvidia GPU passthrouh for Linux

### DIFF
--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -26,7 +26,7 @@ class Start(Command, ContainerCreation, ContainerSpawnShell):
             "Get a [blue]tmux[/blue] shell": "exegol start --shell [blue]tmux[/blue]",
             "Share a specific [blue]hardware device[/blue] [bright_black](e.g. Proxmark)[/bright_black]": "exegol start -d [bright_magenta]/dev/ttyACM0[/bright_magenta]",
             "Share every [blue]USB device[/blue] connected to the host": "exegol start -d [magenta]/dev/bus/usb/[/magenta]",
-            "Enable [blue]NVIDIA GPU[/blue] passthrough": "exegol start [blue]gpu[/blue] [bright_blue]free[/bright_blue] [magenta]--gpu[/magenta]",
+            "Enable [blue]NVIDIA GPU[/blue] passthrough": "exegol start [blue]gpu[/blue] [bright_blue]free[/bright_blue] [magenta]--nvidia-gpu[/magenta]",
         }
 
     def __call__(self, *args, **kwargs):

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -26,7 +26,7 @@ class Start(Command, ContainerCreation, ContainerSpawnShell):
             "Get a [blue]tmux[/blue] shell": "exegol start --shell [blue]tmux[/blue]",
             "Share a specific [blue]hardware device[/blue] [bright_black](e.g. Proxmark)[/bright_black]": "exegol start -d [bright_magenta]/dev/ttyACM0[/bright_magenta]",
             "Share every [blue]USB device[/blue] connected to the host": "exegol start -d [magenta]/dev/bus/usb/[/magenta]",
-            "Enable [blue]NVIDIA GPU[/blue] passthrough": "exegol start [blue]gpu[/blue] [bright_blue]free[/bright_blue] [magenta]--nvidia-gpu[/magenta]",
+            "Enable [blue]NVIDIA GPU[/blue] passthrough": "exegol start [blue]gpu[/blue] [bright_blue]free[/bright_blue] --gpu [magenta]nvidia[/magenta]",
         }
 
     def __call__(self, *args, **kwargs):

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -26,6 +26,7 @@ class Start(Command, ContainerCreation, ContainerSpawnShell):
             "Get a [blue]tmux[/blue] shell": "exegol start --shell [blue]tmux[/blue]",
             "Share a specific [blue]hardware device[/blue] [bright_black](e.g. Proxmark)[/bright_black]": "exegol start -d [bright_magenta]/dev/ttyACM0[/bright_magenta]",
             "Share every [blue]USB device[/blue] connected to the host": "exegol start -d [magenta]/dev/bus/usb/[/magenta]",
+            "Enable [blue]NVIDIA GPU[/blue] passthrough": "exegol start [blue]gpu[/blue] [bright_blue]free[/bright_blue] [magenta]--gpu[/magenta]",
         }
 
     def __call__(self, *args, **kwargs):

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -244,8 +244,8 @@ class ContainerCreation(ContainerSelector, ImageSelector):
         self.gpu = Option("--gpu",
                           dest="gpu",
                           choices=["nvidia"],
-                          default=[],
-                          action="append",
+                          default=None,
+                          action="store",
                           help="Enable GPU passthrough using Docker CDI on Linux hosts (example: --gpu nvidia)")
 
         self.hosts_file = Option("--hosts-file",

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -240,7 +240,7 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               dest="devices",
                               default=[],
                               action="append",
-                              help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/)")
+                              help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/ -d nvidia.com/gpu=all)")
 
         self.hosts_file = Option("--hosts-file",
                         dest="hosts_file",

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -241,6 +241,11 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               default=[],
                               action="append",
                               help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/ -d nvidia.com/gpu=all)")
+        self.gpu = Option("--gpu",
+                          dest="gpu",
+                          action="store_true",
+                          default=False,
+                          help="Enable NVIDIA GPU passthrough using Docker CDI on Linux hosts (equivalent to: -d nvidia.com/gpu=all)")
 
         self.hosts_file = Option("--hosts-file",
                         dest="hosts_file",
@@ -263,6 +268,7 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                                   {"arg": self.hostname, "required": False},
                                   {"arg": self.privileged, "required": False},
                                   {"arg": self.devices, "required": False},
+                                  {"arg": self.gpu, "required": False},
                                   {"arg": self.X11, "required": False},
                                   {"arg": self.my_resources, "required": False},
                                   {"arg": self.exegol_resources, "required": False},

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -241,7 +241,7 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               default=[],
                               action="append",
                               help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/ -d nvidia.com/gpu=all)")
-        self.gpu = Option("--gpu",
+        self.gpu = Option("--nvidia-gpu",
                           dest="gpu",
                           action="store_true",
                           default=False,

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -241,11 +241,12 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               default=[],
                               action="append",
                               help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/ -d nvidia.com/gpu=all)")
-        self.gpu = Option("--nvidia-gpu",
+        self.gpu = Option("--gpu",
                           dest="gpu",
-                          action="store_true",
-                          default=False,
-                          help="Enable NVIDIA GPU passthrough using Docker CDI on Linux hosts (equivalent to: -d nvidia.com/gpu=all)")
+                          choices=["nvidia"],
+                          default=[],
+                          action="append",
+                          help="Enable GPU passthrough using Docker CDI on Linux hosts (example: --gpu nvidia)")
 
         self.hosts_file = Option("--hosts-file",
                         dest="hosts_file",

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -113,6 +113,7 @@ class ContainerConfig:
         self.__wrapper_start_enabled: bool = False
         self.__mounts: List[Mount] = []
         self.__devices: List[str] = []
+        self.__device_requests: List[Dict[str, Union[str, int, List[str]]]] = []
         self.__capabilities: List[str] = []
         self.__sysctls: Dict[str, str] = {}
         self.__envs: Dict[str, str] = {}
@@ -190,6 +191,17 @@ class ContainerConfig:
                 self.__devices.append(
                     f"{device.get('PathOnHost', '?')}:{device.get('PathInContainer', '?')}:{device.get('CgroupPermissions', '?')}")
         logger.debug(f"└── Load devices : {self.__devices}")
+        device_requests = host_config.get("DeviceRequests", [])
+        if device_requests is not None:
+            for request in device_requests:
+                if request is None:
+                    continue
+                driver = request.get("Driver")
+                device_ids = request.get("DeviceIDs")
+                if driver == "cdi" and isinstance(device_ids, list):
+                    for device_id in device_ids:
+                        if isinstance(device_id, str):
+                            self.__addCdiDevice(device_id)
         extra_hosts = host_config.get("ExtraHosts", [])
         for entry in extra_hosts:
             hostname, ip = entry.rsplit(":", 1)
@@ -1330,6 +1342,10 @@ class ContainerConfig:
         """Devices config getter"""
         return self.__devices
 
+    def getDeviceRequests(self) -> List[Dict[str, Union[str, int, List[str]]]]:
+        """Device requests config getter (used for CDI selectors)."""
+        return self.__device_requests
+
     def addEnv(self, key: str, value: str) -> None:
         """Add or update an environment variable to the container configuration"""
         self.__envs[key] = value
@@ -1566,7 +1582,19 @@ class ContainerConfig:
                     logger.warning("Orbstack does not support (yet) USB device passthrough.")
                     logger.verbose("Official doc: https://docs.orbstack.dev/machines/#usb-devices")
                 logger.critical("Device configuration cannot be applied, aborting operation.")
+        if self.__isCdiDevice(user_device_config):
+            self.__addCdiDevice(user_device_config)
+            return
         self.__addDevice(user_device_config)
+
+    def __addCdiDevice(self, device_selector: str) -> None:
+        """Add a CDI selector as a Docker device request."""
+        self.__device_requests.append({"Driver": "cdi", "Count": 0, "DeviceIDs": [device_selector]})
+
+    @staticmethod
+    def __isCdiDevice(device: str) -> bool:
+        """Return True when user input looks like a CDI selector."""
+        return re.match(r"^[^/:]+/[^:=]+=[^:]+$", device) is not None
 
     async def addRawPort(self, user_test_port: str) -> None:
         """Add port config or range of ports from user input.
@@ -1711,11 +1739,21 @@ class ContainerConfig:
     def getTextDevices(self, verbose: bool = False) -> str:
         """Text formatter for Devices configuration. The verbose mode show full device configuration."""
         result = ''
-        for device in self.__devices:
+        text_devices = list(self.__devices)
+        for request in self.__device_requests:
+            driver = request.get("Driver")
+            device_ids = request.get("DeviceIDs")
+            if driver == "cdi" and isinstance(device_ids, list):
+                text_devices.extend([device for device in device_ids if isinstance(device, str)])
+        for device in text_devices:
             if verbose:
                 result += f"{device}{os.linesep}"
             else:
-                src, dest = device.split(':')[:2]
+                split_device = device.split(':')
+                if len(split_device) < 2:
+                    result += f"{device}{os.linesep}"
+                    continue
+                src, dest = split_device[:2]
                 if src == dest:
                     result += f"{src}{os.linesep}"
                 else:

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -358,7 +358,7 @@ class ContainerConfig:
                     await self.addRawVolume(volume)
             if ParametersManager().gpu:
                 if EnvInfo.isMacHost() or EnvInfo.isWindowsHost():
-                    logger.critical("The --gpu option is currently supported only on Linux hosts.")
+                    logger.critical("The --nvidia-gpu option is currently supported only on Linux hosts.")
                 if "nvidia.com/gpu=all" not in ParametersManager().devices:
                     self.addUserDevice("nvidia.com/gpu=all")
             if ParametersManager().devices is not None:

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -1603,7 +1603,7 @@ class ContainerConfig:
 
     def __addCdiDevice(self, device_selector: str) -> None:
         """Add a CDI selector as a Docker device request."""
-        self.__device_requests.append({"Driver": "cdi", "Count": 0, "DeviceIDs": [device_selector]})
+        self.__device_requests.append({"Driver": "cdi", "DeviceIDs": [device_selector]})
 
     @staticmethod
     def __isCdiDevice(device: str) -> bool:

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -358,9 +358,16 @@ class ContainerConfig:
                     await self.addRawVolume(volume)
             if ParametersManager().gpu:
                 if EnvInfo.isMacHost() or EnvInfo.isWindowsHost():
-                    logger.critical("The --nvidia-gpu option is currently supported only on Linux hosts.")
-                if "nvidia.com/gpu=all" not in ParametersManager().devices:
-                    self.addUserDevice("nvidia.com/gpu=all")
+                    logger.critical("The --gpu option is currently supported only on Linux hosts.")
+                gpu_cdi_selectors = {
+                    "nvidia": "nvidia.com/gpu=all",
+                }
+                for gpu_vendor in sorted(set(ParametersManager().gpu)):
+                    cdi_selector = gpu_cdi_selectors.get(gpu_vendor)
+                    if cdi_selector is None:
+                        logger.critical(f"Unsupported GPU vendor for --gpu: {gpu_vendor}")
+                    if cdi_selector not in ParametersManager().devices:
+                        self.addUserDevice(cdi_selector)
             if ParametersManager().devices is not None:
                 for device in ParametersManager().devices:
                     self.addUserDevice(device)

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -358,18 +358,18 @@ class ContainerConfig:
             if ParametersManager().volumes is not None:
                 for volume in ParametersManager().volumes:
                     await self.addRawVolume(volume)
-            if ParametersManager().gpu:
+            gpu_vendor = ParametersManager().gpu
+            if gpu_vendor:
                 if EnvInfo.isMacHost() or EnvInfo.isWindowsHost():
                     logger.critical("The --gpu option is currently supported only on Linux hosts.")
                 gpu_cdi_selectors = {
                     "nvidia": "nvidia.com/gpu=all",
                 }
-                for gpu_vendor in sorted(set(ParametersManager().gpu)):
-                    cdi_selector = gpu_cdi_selectors.get(gpu_vendor)
-                    if cdi_selector is None:
-                        logger.critical(f"Unsupported GPU vendor for --gpu: {gpu_vendor}")
-                    if cdi_selector not in ParametersManager().devices:
-                        self.addUserDevice(cdi_selector)
+                cdi_selector = gpu_cdi_selectors.get(gpu_vendor)
+                if cdi_selector is None:
+                    logger.critical(f"Unsupported GPU vendor for --gpu: {gpu_vendor}")
+                if cdi_selector not in ParametersManager().devices:
+                    self.addUserDevice(cdi_selector)
             if ParametersManager().devices is not None:
                 for device in ParametersManager().devices:
                     self.addUserDevice(device)

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -356,6 +356,11 @@ class ContainerConfig:
             if ParametersManager().volumes is not None:
                 for volume in ParametersManager().volumes:
                     await self.addRawVolume(volume)
+            if ParametersManager().gpu:
+                if EnvInfo.isMacHost() or EnvInfo.isWindowsHost():
+                    logger.critical("The --gpu option is currently supported only on Linux hosts.")
+                if "nvidia.com/gpu=all" not in ParametersManager().devices:
+                    self.addUserDevice("nvidia.com/gpu=all")
             if ParametersManager().devices is not None:
                 for device in ParametersManager().devices:
                     self.addUserDevice(device)

--- a/exegol/model/ContainerConfig.py
+++ b/exegol/model/ContainerConfig.py
@@ -202,6 +202,8 @@ class ContainerConfig:
                     for device_id in device_ids:
                         if isinstance(device_id, str):
                             self.__addCdiDevice(device_id)
+                else:
+                    logger.debug(f"Unsupported device request: {request}")
         extra_hosts = host_config.get("ExtraHosts", [])
         for entry in extra_hosts:
             hostname, ip = entry.rsplit(":", 1)

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -150,7 +150,18 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                 self.__container.start()
             except APIError as e:
                 logger.debug(e)
-                logger.critical(f"Docker raised a critical error when starting the container [green]{self.name}[/green], error message is: {e.explanation}")
+                explanation = e.explanation
+                if explanation is None:
+                    explanation = ""
+                elif isinstance(explanation, bytes):
+                    explanation = explanation.decode("utf-8", errors="ignore")
+                message = str(explanation)
+                lower_message = message.lower()
+                message = message.replace('[', '\\[')
+                logger.error(f"Docker raised a critical error when starting the container [green]{self.name}[/green], error message is: {message}")
+                if "cdi device injection failed" in lower_message and "nvidia.com/gpu=all" in lower_message:
+                    logger.warning("Hint: verify NVIDIA CDI is configured (e.g. nvidia-container-toolkit installed and Docker CDI enabled).")
+                logger.critical("Error while starting exegol container. Exiting.")
             if not self.config.legacy_entrypoint:  # TODO improve startup compatibility check
                 try:
                     # Try to find log / startup messages. Will time out after 2 seconds if the image don't support status update through container logs.

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -150,17 +150,11 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                 self.__container.start()
             except APIError as e:
                 logger.debug(e)
-                explanation = e.explanation
-                if explanation is None:
-                    explanation = ""
-                elif isinstance(explanation, bytes):
-                    explanation = explanation.decode("utf-8", errors="ignore")
-                message = str(explanation)
-                lower_message = message.lower()
-                message = message.replace('[', '\\[')
-                logger.error(f"Docker raised a critical error when starting the container [green]{self.name}[/green], error message is: {message}")
-                if "cdi device injection failed" in lower_message and "nvidia.com/gpu=all" in lower_message:
+                explanation = str(e.explanation if e.explanation is not None else "")
+                if "cdi device injection failed" in explanation.lower() and "nvidia.com/gpu=all" in explanation.lower():
                     logger.warning("Hint: verify NVIDIA CDI is configured (e.g. nvidia-container-toolkit installed and Docker CDI enabled).")
+                explanation = explanation.replace('[', '\\[')
+                logger.error(f"Docker raised a critical error when starting the container [green]{self.name}[/green], error message is: {explanation}")
                 logger.critical("Error while starting exegol container. Exiting.")
             if not self.config.legacy_entrypoint:  # TODO improve startup compatibility check
                 try:

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -152,7 +152,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
                 logger.debug(e)
                 explanation = str(e.explanation if e.explanation is not None else "")
                 if "cdi device injection failed" in explanation.lower() and "nvidia.com/gpu=all" in explanation.lower():
-                    logger.warning("Hint: verify NVIDIA CDI is configured (e.g. nvidia-container-toolkit installed and Docker CDI enabled).")
+                    logger.warning("Hint: verify that nvidia-container-toolkit is installed. See https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html")
                 explanation = explanation.replace('[', '\\[')
                 logger.error(f"Docker raised a critical error when starting the container [green]{self.name}[/green], error message is: {explanation}")
                 logger.critical("Error while starting exegol container. Exiting.")

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -129,6 +129,7 @@ class DockerUtils(metaclass=MetaSingleton):
                        "hostname": model.config.hostname,
                        "extra_hosts": model.config.getExtraHost(),
                        "devices": model.config.getDevices(),
+                       "device_requests": model.config.getDeviceRequests(),
                        "environment": model.config.getEnvs(),
                        "labels": model.config.getLabels(),
                        "ports": model.config.getPorts(),


### PR DESCRIPTION
# Description

> [!NOTE]
> AI tooling was used extensively while developing this PR. I did test and reviewed the resulting implementation.

> [!NOTE]
> The idea of exposing GPUs to Exegol containers using CDI was inspired by https://github.com/p3ta00/exegol-gpu

This PR adds support for Docker CDI device selectors in Exegol.

It keeps the existing `--device` CLI interface, but distinguishes internally between:
- classic host device paths (`/dev/...`)
- CDI selectors (`vendor.com/class=name`)

The two cases are forwarded to the appropriate Docker API fields:
- path devices → `devices`
- CDI selectors → `device_requests`

This keeps existing behaviour unchanged for traditional device mappings while making it easier to use CDI-exposed devices, such as GPUs.

This PR also adds a `--gpu nvidia` convenience flag on Linux hosts, acting as a shortcut for:
- `-d nvidia.com/gpu=all`

The implementation relies on CDI device selectors (e.g. `nvidia.com/gpu=all`) rather than the Docker `--gpus` flag.
CDI provides a vendor-neutral mechanism for exposing hardware devices to containers. In theory, any GPU supported by a CDI specification (e.g.`amd.com/gpu` or `intel.com/gpu`) could be exposed in the same way using`--device`, without requiring changes in Exegol.

# Test

Before  
<img width="2437" height="771" alt="image" src="https://github.com/user-attachments/assets/ea99efc3-2860-4b71-8edd-5dd24c7f37bd" />

After  
<img width="2489" height="1361" alt="image" src="https://github.com/user-attachments/assets/14c45968-3a80-4b28-bdcd-2af7eb2bb016" />

This has only been tested on Linux x86_64 using nvidia gpu

# Related issues

No related issue, but this is related to [this pull request](https://github.com/ThePorgs/Exegol/pull/254) and is narrower in scope.

Instead of adding GPU detection or automatic GPU enablement, this patch adds generic CDI selector support to the existing `--device` input, while routing it to the proper Docker API field internally.

# Point of attention

`--gpu` flag is currently limited to Linux hosts and is implemented as a convenience shortcut for NVIDIA CDI passthrough.

This has only been validated on Linux Docker hosts. In theory it could also work on Docker Desktop for Windows with WSL2 GPU support ([see](https://docs.docker.com/desktop/features/gpu/)) but I did not try