### PR TITLE
fix: pin workflow actions to commit SHA

### DIFF
--- a/.github/workflows/entrypoint_nightly.yml
+++ b/.github/workflows/entrypoint_nightly.yml
@@ -21,11 +21,11 @@ jobs:
       id-token: write
     needs: test
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
         with:
           python-version: "3.12"
       - name: Build Exegol

--- a/.github/workflows/entrypoint_prerelease.yml
+++ b/.github/workflows/entrypoint_prerelease.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Find spawn.sh script version

--- a/.github/workflows/entrypoint_release.yml
+++ b/.github/workflows/entrypoint_release.yml
@@ -19,11 +19,11 @@ jobs:
       id-token: write
     needs: test
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
         with:
           python-version: "3.12"
       - name: Build Exegol

--- a/.github/workflows/sub_testing.yml
+++ b/.github/workflows/sub_testing.yml
@@ -8,11 +8,11 @@ jobs:
     name: Code testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
         with:
           python-version: "3.12"
       - name: Install requirements
@@ -36,11 +36,11 @@ jobs:
         version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [win32, linux, darwin]
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
         with:
           python-version: ${{ matrix.version }}
       - name: Install requirements
@@ -58,9 +58,9 @@ jobs:
 #        os: [ ubuntu-latest, macOS-latest, windows-latest ]
 #
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 #      - name: Set up PDM
-#        uses: pdm-project/setup-pdm@v4
+#        uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
 #        with:
 #          python-version: ${{ matrix.python-version }}
 #
@@ -74,11 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: testing
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v4
+        uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
         with:
           python-version: "3.12"
       - name: Build Exegol


### PR DESCRIPTION
# Description

Tags and branches in GitHub are mutable; a repository owner or an attacker who gains access to the upstream action repository can move a tag to a different commit. This creates a supply chain risk where malicious code could be introduced into our CI/CD environment without changing our workflow files.

# Related issues

None found.

# Point of attention

Make sure that the pinned versions are correct.