### PR TITLE
Use shlex to quote environment variables

### DIFF
--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -1,6 +1,7 @@
 import asyncio
 import errno
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -222,7 +223,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
         envs = self.config.getShellEnvs()
         options = ""
         if len(envs) > 0:
-            options += f" -e {' -e '.join(envs)}"
+            options += " " + " ".join(f"-e {shlex.quote(env)}" for env in envs)
         if spawn_all_capabilities:
             options += " --privileged"
         cmd = f"docker exec{options} -ti {self.getFullId()} {self.config.getShellCommand()}"


### PR DESCRIPTION
## Problem

When opening a shell on a container with `-e/--env`, Exegol builds the `docker exec` command as a single string and runs it through `os.system()`, which executes it via `/bin/sh`. The environment values are interpolated without any quoting:

https://github.com/ThePorgs/Exegol/blob/bf4f7aa7ed253cc4182c75f25016cc378c67c1f2/exegol/model/ExegolContainer.py#L225-L228

As soon as an environment value contains a character that is special to the shell, the command breaks.

## Reproduction

```bash
export MYVAR='abc;def #ghi'
exegol start mycontainer -e MYVAR

[*] Creating new exegol container
[+] Exegol container successfully created!
[+] Successfully deployed my-resources!
[*] Location of the exegol workspace on the host : /home/pixis/.exegol/workspaces/mycontainer
[+] Opening zsh shell in Exegol mycontainer
[+] Using system value for env MYVAR.
docker: 'docker exec' requires at least 2 arguments

Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]

See 'docker exec --help' for more information
sh: 1: def: not found
```

The ; terminates the docker exec invocation early (so Docker complains about missing arguments), and the remainder of the value is executed by the shell as a separate command.

This can be weaponized like so by executing arbitrary command **on the host**

```bash
$ MYVAR='$(echo owned > /tmp/pwned)'
$ exegol start mycontainer -e MYVAR
[*] Exegol Enterprise is currently in version v5.1.10
[*] More about Exegol at: https://exegol.com
[*] Skipping interactive mode (arguments supplied)
[*] Location of the exegol workspace on the host : /home/pixis/.exegol/workspaces/mycontainer
[+] Opening zsh shell in Exegol mycontainer
[+] Using system value for env MYVAR.
[Jun 19, 2026 - 14:04:43 (CEST)] exegol-mycontainer /workspace # exit
$ cat /tmp/pwned
owned
```

## Fix

Shell-quote each environment entry with shlex.quote() before building the command string. 

```python
options += " " + " ".join(f"-e {shlex.quote(env)}" for env in envs)
```