### PR TITLE
Fix: migrate leftover readthedocs links to docs.exegol.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://discord.gg/cXThyp7D6P
     about: 'Use the #open-a-ticket channel to ask your question.'
   - name: Read the Exegol documentation
-    url: https://exegol.readthedocs.io/
+    url: https://docs.exegol.com/
     about: 'An answer to your question may already be available in the documentation!'
   - name: Create an issue regarding the Exegol [IMAGE] project
     url: https://github.com/ThePorgs/Exegol-images/issues

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 # Description
 
-> A description of your PR, what it brings or corrects. Don't forget to configure your PR to the dev branch (cf. https://exegol.readthedocs.io/en/latest/community/contributors.html)
+> A description of your PR, what it brings or corrects. Don't forget to configure your PR to the dev branch (cf. https://docs.exegol.com/contribute/wrapper)
 
 # Related issues
 
-> If your PR responds to an issue for a bug fix or feature request, make sure to includes references to the issues (e.g. "fixes #xxxx").
+> If your PR responds to an issue for a bug fix or feature request, make sure to include references to the issues (e.g. "fixes #xxxx").
 
 # Point of attention
 


### PR DESCRIPTION
# Description

Hey! I was looking into how to contribute to the project and I came across some links that seem to point to the old platform you used to host the documentation, in the GitHub issue and PR templates. So here's a tiny fix that just updates the URLs (from `exegol.readthedocs.io` to `docs.exegol.com`) and corrects a small typo in the project :)

`docs.exegol.com` is already the documentation domain referenced in `CONTRIBUTING.md` and `README.md`, so this just finishes that migration for the `.github/` templates.

Thanks for your work! :)
