### PR TITLE
Speed up CLI autocompletion and make it installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ pdm.lock
 
 # Cursor files
 .cursor/
+
+# Claude Code files
+.claude/
+CLAUDE.md

--- a/exegol/config/ConstantConfig.py
+++ b/exegol/config/ConstantConfig.py
@@ -20,6 +20,9 @@ class ConstantConfig:
     spawn_context_path_obj: Path = src_root_path_obj / "exegol/utils/imgsync/spawn.sh"
     # Path to the EULA docs
     eula_path: Path = src_root_path_obj / "exegol/utils/docs/eula.md"
+    # True when the current process has been spawned by the shell completion system (argcomplete).
+    # In this mode, everything not strictly required to supply completion options must be skipped.
+    completion_mode: bool = bool(os.getenv("_ARGCOMPLETE"))
     # Exegol config directory
     exegol_config_path: Path = Path().home() / ".exegol"
     __sudo_home = os.getenv("SUDO_HOME")

--- a/exegol/config/DataCache.py
+++ b/exegol/config/DataCache.py
@@ -1,7 +1,7 @@
 import json
 from typing import List
 
-from exegol.model.CacheModels import ImageCacheModel, WrapperCacheModel, CacheDB, ImagesCacheModel
+from exegol.model.CacheModels import ContainerCacheModel, ContainersCacheModel, ImageCacheModel, WrapperCacheModel, CacheDB, ImagesCacheModel
 from exegol.utils.DataFileUtils import DataFileUtils
 from exegol.utils.ExeLog import logger
 from exegol.utils.MetaSingleton import MetaSingleton
@@ -31,6 +31,15 @@ class DataCache(DataFileUtils, metaclass=MetaSingleton):
                     type: STR (local|remote)
                 }
             ]
+        containers:
+            metadata: {
+                    last_check: DATE
+            }
+            data: [
+                {
+                    name: STR (container tag, without the 'exegol-' prefix)
+                }
+            ]
     }
     """
 
@@ -42,8 +51,13 @@ class DataCache(DataFileUtils, metaclass=MetaSingleton):
         super().__init__(".datacache", "json")
 
     def _process_data(self) -> None:
-        if len(self._raw_data) >= 2:
-            self.__cache_data.load(**self._raw_data)
+        if type(self._raw_data) is dict and len(self._raw_data) >= 2:
+            try:
+                self.__cache_data.load(**self._raw_data)
+            except (TypeError, NotImplementedError):
+                # An unreadable cache must never break a normal execution, it will be rebuilt from scratch
+                logger.debug("Unsupported cache data format, resetting the cache.")
+                self.__cache_data = CacheDB()
 
     def _build_file_content(self) -> str:
         return json.dumps(self.__cache_data, cls=self.ObjectJSONEncoder)
@@ -58,6 +72,31 @@ class DataCache(DataFileUtils, metaclass=MetaSingleton):
     def get_images_data(self) -> ImagesCacheModel:
         """Get Images information from cache"""
         return self.__cache_data.images
+
+    def get_containers_data(self) -> ContainersCacheModel:
+        """Get Containers information from cache"""
+        return self.__cache_data.containers
+
+    def update_container_cache(self, names: List[str]) -> None:
+        """Refresh container cache data.
+        This cache is only used to supply CLI autocompletion, it must never be used for correctness."""
+        if [c.name for c in self.__cache_data.containers.data] == names:
+            # Nothing changed, skip the file update
+            return
+        logger.debug("Updating container cache data")
+        self.__cache_data.containers = ContainersCacheModel([ContainerCacheModel(name) for name in names])
+        self.save_updates()
+
+    def add_container_cache(self, name: str) -> None:
+        """Add a single container to the cache (autocompletion data)"""
+        names = [c.name for c in self.__cache_data.containers.data]
+        if name not in names:
+            names.append(name)
+            self.update_container_cache(names)
+
+    def remove_container_cache(self, name: str) -> None:
+        """Remove a single container from the cache (autocompletion data)"""
+        self.update_container_cache([c.name for c in self.__cache_data.containers.data if c.name != name])
 
     async def update_image_cache(self, images: List) -> None:
         """Refresh image cache data"""

--- a/exegol/config/UserConfig.py
+++ b/exegol/config/UserConfig.py
@@ -8,7 +8,6 @@ from exegol.utils.DataFileUtils import DataFileUtils
 from exegol.utils.ExeLog import logger
 from exegol.utils.MetaSingleton import MetaSingleton
 from exegol.utils.NetworkUtils import NetworkUtils
-from exegol.utils.SessionHandler import SessionHandler
 
 
 class UserConfig(DataFileUtils, metaclass=MetaSingleton):
@@ -200,14 +199,21 @@ config:
         self.network_default_mode = self._load_config_str(network_data, 'default_network', self.network_default_mode, choices=NetworkUtils.get_options())
         self.network_dedicated_range = self._load_config_str(network_data, 'exegol_dedicated_range')  # Dynamic default
         self.network_default_netmask = NetworkUtils.parse_netmask(self._load_config_str(network_data, 'exegol_default_netmask', str(self.network_default_netmask)), default=self.network_default_netmask)
-        if SessionHandler().pro_feature_access():
-            self.network_fallback_mode = self._load_config_str(network_data, 'fallback_network', self.network_fallback_mode, choices={'nat', 'docker'})
-        else:
+        if ConstantConfig.completion_mode:
+            # The licensed features are never needed to supply completion options,
+            # loading the session here would import the whole license stack and slow down every completion
             self.network_fallback_mode = 'docker'
+        else:
+            # Imported locally to keep the CLI parser light (see the shell completion fast path)
+            from exegol.utils.SessionHandler import SessionHandler
+            if SessionHandler().pro_feature_access():
+                self.network_fallback_mode = self._load_config_str(network_data, 'fallback_network', self.network_fallback_mode, choices={'nat', 'docker'})
+            else:
+                self.network_fallback_mode = 'docker'
 
-        # Enterprise features
-        if SessionHandler().enterprise_feature_access():
-            self.custom_images = self._load_config_list_str(config_data, "custom_images")
+            # Enterprise features
+            if SessionHandler().enterprise_feature_access():
+                self.custom_images = self._load_config_list_str(config_data, "custom_images")
 
     def get_configs(self) -> List[str]:
         """User configs getter each options"""
@@ -235,6 +241,8 @@ config:
             f"Network range: [blue]{self.network_dedicated_range}[/blue]",
             f"Network exegol netmask: [blue]{self.network_default_netmask}[/blue]",
         ]
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.utils.SessionHandler import SessionHandler
         if SessionHandler().enterprise_feature_access():
             if len(self.custom_images) > 0:
                 configs.append(f"Custom images:")

--- a/exegol/console/cli/ExegolCompleter.py
+++ b/exegol/console/cli/ExegolCompleter.py
@@ -1,26 +1,31 @@
-import asyncio
 from argparse import Namespace
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 
 from exegol.config.DataCache import DataCache
 from exegol.config.UserConfig import UserConfig
-from exegol.manager.UpdateManager import UpdateManager
-from exegol.utils.DockerUtils import DockerUtils
 from exegol.utils.NetworkUtils import NetworkUtils
 
 
 # Debug : argcomplete.warn('debug message')
 
+def _filterPrefix(data: List[str], prefix: str) -> Tuple[str, ...]:
+    """Filter a list of completion options with the prefix already typed by the user"""
+    if not prefix:
+        return tuple(data)
+    return tuple(obj for obj in data if obj.lower().startswith(prefix.lower()))
+
+
 def ContainerCompleter(prefix: str, parsed_args: Namespace, **kwargs) -> Tuple[str, ...]:
-    """Function to dynamically load a container list for CLI autocompletion purpose"""
-    container_list = asyncio.run(DockerUtils().listContainers())
-    data = [c.name for c in container_list]
-    for obj in data:
-        # filter data if needed
-        if prefix and not obj.lower().startswith(prefix.lower()):
-            data.remove(obj)
-    return tuple(data)
+    """Function to dynamically load a container list for CLI autocompletion purpose.
+    Only the local cache is read here: the completer must be instantaneous
+    and must never interact with the docker daemon."""
+    try:
+        data = [container.name for container in DataCache().get_containers_data().data]
+    except Exception:
+        # A completer must never fail, supplying no option is better than breaking the user's shell completion
+        return ()
+    return _filterPrefix(data, prefix)
 
 
 def ImageCompleter(prefix: str, parsed_args: Namespace, **kwargs) -> Tuple[str, ...]:
@@ -38,16 +43,14 @@ def ImageCompleter(prefix: str, parsed_args: Namespace, **kwargs) -> Tuple[str, 
     if len(data) == 0:
         # Fallback with default data if the cache is not initialized yet
         data = ["full", "nightly", "ad", "web", "light", "osint", "free"]
-    for obj in data:
-        # filter data if needed
-        if prefix and not obj.lower().startswith(prefix.lower()):
-            data.remove(obj)
-    return tuple(data)
+    return _filterPrefix(data, prefix)
 
 
 def HybridContainerImageCompleter(prefix: str, parsed_args: Namespace, **kwargs) -> Tuple[str, ...]:
     """Hybrid completer for auto-complet. The selector on exec action is hybrid between image and container depending on the mode (tmp or not).
     This completer will supply the adequate data."""
+    if parsed_args is None:
+        return ()
     # "exec" parameter is filled first before the selector argument
     # If "selector" is null but the selector parameter is set in the first exec slot, no longer need to supply completer options
     if parsed_args.selector is None and parsed_args.exec is not None and len(parsed_args.exec) > 0:
@@ -65,44 +68,51 @@ def BuildProfileCompleter(prefix: str, parsed_args: Namespace, **kwargs) -> Tupl
     if parsed_args is not None and parsed_args.imagetag is None:
         return ()
 
-    # Handle custom build path
-    if parsed_args is not None and parsed_args.build_path is not None:
-        custom_build_path = Path(parsed_args.build_path).expanduser().absolute()
-        # Check if we have a directory or a file to select the project directory
-        if not custom_build_path.is_dir():
-            custom_build_path = custom_build_path.parent
-        build_path = custom_build_path
-    else:
-        # Default build path
-        build_path = Path(UserConfig().exegol_images_path)
+    try:
+        # Handle custom build path
+        if parsed_args is not None and parsed_args.build_path is not None:
+            custom_build_path = Path(parsed_args.build_path).expanduser().absolute()
+            # Check if we have a directory or a file to select the project directory
+            if not custom_build_path.is_dir():
+                custom_build_path = custom_build_path.parent
+            build_path = custom_build_path
+        else:
+            # Default build path
+            build_path = Path(UserConfig().exegol_images_path)
 
-    # Check if directory path exist
-    if not build_path.is_dir():
-        return tuple()
+        # Check if directory path exist
+        if not build_path.is_dir():
+            return tuple()
 
-    # Find profile list
-    data = list(UpdateManager.listBuildProfiles(profiles_path=build_path).keys())
-    for obj in data:
-        if prefix and not obj.lower().startswith(prefix.lower()):
-            data.remove(obj)
-    return tuple(data)
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.UpdateManager import UpdateManager
+        # Find profile list
+        data = list(UpdateManager.listBuildProfiles(profiles_path=build_path).keys())
+    except Exception:
+        # A completer must never fail, supplying no option is better than breaking the user's shell completion
+        return ()
+    return _filterPrefix(data, prefix)
 
 
 def DesktopConfigCompleter(prefix: str, **kwargs) -> Tuple[str, ...]:
     result = []
-    parts = prefix.split(':')
-    if len(parts) <= 1:
-        # First part, suggest available protocol
-        proto_options = list(UserConfig.desktop_available_proto)
-        for obj in proto_options:
-            if prefix is not None and obj.lower().startswith(prefix.lower()):
-                result.append(obj)
-    elif len(parts) == 2:
-        # Second part, autocomplet host interfaces
-        addr_options = NetworkUtils.get_host_addresses()
-        for obj in addr_options:
-            if obj.startswith(parts[-1]):
-                result.append(parts[0] + ':' + obj)
+    try:
+        parts = prefix.split(':')
+        if len(parts) <= 1:
+            # First part, suggest available protocol
+            proto_options = list(UserConfig.desktop_available_proto)
+            for obj in proto_options:
+                if prefix is not None and obj.lower().startswith(prefix.lower()):
+                    result.append(obj)
+        elif len(parts) == 2:
+            # Second part, autocomplet host interfaces
+            addr_options = NetworkUtils.get_host_addresses()
+            for obj in addr_options:
+                if obj.startswith(parts[-1]):
+                    result.append(parts[0] + ':' + obj)
+    except Exception:
+        # A completer must never fail, supplying no option is better than breaking the user's shell completion
+        return ()
 
     return tuple(result)
 

--- a/exegol/console/cli/actions/Command.py
+++ b/exegol/console/cli/actions/Command.py
@@ -44,6 +44,12 @@ class GroupArg:
 class Command:
     """The Command class is the root of all CLI actions"""
 
+    # Set to False on actions that must be able to run without a working docker daemon
+    require_docker: bool = True
+    # Set to True on actions whose stdout is machine-readable data (i.e. meant to be redirected to a file).
+    # Every log message is sent to stderr instead, to keep the redirected output clean.
+    stdout_is_data: bool = False
+
     def __init__(self) -> None:
         # Root command usages (can be overwritten by subclasses to display different use cases)
         self._pre_usages = ""

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -1,6 +1,8 @@
 import os
 from typing import Optional
 
+from argcomplete.completers import DirectoriesCompleter, FilesCompleter
+
 from exegol.console.cli.ExegolCompleter import HybridContainerImageCompleter, VoidCompleter, BuildProfileCompleter, ImageCompleter
 from exegol.console.cli.actions.Command import Command, Option, GroupArg
 from exegol.console.cli.actions.GenericParameters import ContainerCreation, ContainerSpawnShell, ContainerMultiSelector, ContainerSelector, ImageSelector, ImageMultiSelector, ContainerStart
@@ -118,12 +120,14 @@ class Build(Command, ImageSelector):
                                 dest="build_log",
                                 metavar="LOGFILE_PATH",
                                 action="store",
-                                help="Write image building logs to a file.")
+                                help="Write image building logs to a file.",
+                                completer=FilesCompleter())
         self.build_path = Option("--build-path",
                                  dest="build_path",
                                  metavar="DOCKERFILES_PATH",
                                  action="store",
-                                 help=f"Path to the dockerfiles and sources.")
+                                 help=f"Path to the dockerfiles and sources.",
+                                 completer=DirectoriesCompleter())
 
         # Create group parameter for container selection
         self.groupArgs.append(GroupArg({"arg": self.build_profile, "required": False},
@@ -408,6 +412,54 @@ class Activate(Command):
         # Imported locally to keep the CLI parser light (see the shell completion fast path)
         from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.activate
+
+
+class Completion(Command):
+    """Generate the shell completion script of the Exegol wrapper"""
+
+    # Printing a static shell script must not require a running docker daemon
+    require_docker = False
+    # The generated script is meant to be redirected to a file, it must be the only thing on stdout
+    stdout_is_data = True
+
+    def __init__(self) -> None:
+        Command.__init__(self)
+
+        self.shell_type = Option("shell_type",
+                                 metavar="SHELL",
+                                 nargs="?",
+                                 action="store",
+                                 choices={"bash", "zsh", "fish", "tcsh", "powershell"},
+                                 default=None,
+                                 help="Shell to generate the completion script for "
+                                      "(default: [blue]auto-detected[/blue])")
+
+        self.groupArgs.append(GroupArg({"arg": self.shell_type, "required": False},
+                                       title="[bright_blue]Completion[/bright_blue][blue]-only options[/blue]"))
+
+        self._pre_usages = ("Once installed, restart your shell to complete container and image names "
+                            "with [blue]<TAB>[/blue]." + os.linesep)
+        self._usages = {
+            "Show the script of the [bright_black](auto-detected)[/bright_black] current shell": "exegol completion",
+            "Show the script of a specific shell": "exegol completion [blue]zsh[/blue]",
+        }
+        self._post_usages = (os.linesep +
+                             "[blue]Installation:[/blue]" + os.linesep +
+                             "  [bright_blue]bash[/bright_blue]" + os.linesep +
+                             "    [i]mkdir -p ~/.local/share/bash-completion/completions[/i]" + os.linesep +
+                             "    [i]exegol completion bash > ~/.local/share/bash-completion/completions/exegol[/i]" + os.linesep +
+                             "  [bright_blue]zsh[/bright_blue] [bright_black](the completion directory must be in your fpath before compinit)[/bright_black]" + os.linesep +
+                             "    [i]mkdir -p ~/.zsh/completions[/i]" + os.linesep +
+                             "    [i]exegol completion zsh > ~/.zsh/completions/_exegol[/i]" + os.linesep +
+                             "    [bright_black]# in ~/.zshrc, before compinit:[/bright_black] [i]fpath=(~/.zsh/completions $fpath)[/i]" + os.linesep +
+                             "  [bright_blue]fish[/bright_blue]" + os.linesep +
+                             "    [i]exegol completion fish > ~/.config/fish/completions/exegol.fish[/i]")
+
+    def __call__(self, *args, **kwargs):
+        logger.debug("Running completion module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
+        return ExegolManager.completion
 
 
 class Version(Command):

--- a/exegol/console/cli/actions/ExegolParameters.py
+++ b/exegol/console/cli/actions/ExegolParameters.py
@@ -4,7 +4,6 @@ from typing import Optional
 from exegol.console.cli.ExegolCompleter import HybridContainerImageCompleter, VoidCompleter, BuildProfileCompleter, ImageCompleter
 from exegol.console.cli.actions.Command import Command, Option, GroupArg
 from exegol.console.cli.actions.GenericParameters import ContainerCreation, ContainerSpawnShell, ContainerMultiSelector, ContainerSelector, ImageSelector, ImageMultiSelector, ContainerStart
-from exegol.manager.ExegolManager import ExegolManager
 from exegol.utils.ExeLog import logger
 
 
@@ -29,6 +28,8 @@ class Start(Command, ContainerCreation, ContainerSpawnShell):
         }
 
     def __call__(self, *args, **kwargs):
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.start
 
 
@@ -46,6 +47,8 @@ class Stop(Command, ContainerMultiSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running stop module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.stop
 
 
@@ -64,6 +67,8 @@ class Restart(Command, ContainerSelector, ContainerSpawnShell):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running restart module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.restart
 
 
@@ -90,6 +95,8 @@ class Install(Command, ImageSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running install module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.install
 
 
@@ -131,6 +138,8 @@ class Build(Command, ImageSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running build module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.build
 
 
@@ -162,6 +171,8 @@ class Update(Command, ImageSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running update module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.update
 
 
@@ -204,6 +215,8 @@ class Upgrade(Command, ContainerMultiSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running upgrade module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.upgrade
 
 
@@ -230,6 +243,8 @@ class Uninstall(Command, ImageMultiSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running uninstall module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.uninstall
 
 
@@ -257,6 +272,8 @@ class Remove(Command, ContainerMultiSelector):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running remove module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.remove
 
 
@@ -327,6 +344,8 @@ class Exec(Command, ContainerCreation, ContainerStart):
 
     def __call__(self, *args, **kwargs):
         logger.debug("Running exec module")
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.exec
 
 
@@ -344,6 +363,8 @@ class Info(Command, ContainerSelector):
         }
 
     def __call__(self, *args, **kwargs):
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.info
 
 
@@ -384,6 +405,8 @@ class Activate(Command):
                                        title="[bright_blue]Activate[/bright_blue][blue]-only options[/blue]"))
 
     def __call__(self, *args, **kwargs):
+        # Imported locally to keep the CLI parser light (see the shell completion fast path)
+        from exegol.manager.ExegolManager import ExegolManager
         return ExegolManager.activate
 
 

--- a/exegol/console/cli/actions/GenericParameters.py
+++ b/exegol/console/cli/actions/GenericParameters.py
@@ -217,7 +217,8 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               action="append",
                               default=[],
                               dest="volumes",
-                              help=f"Share a new volume between host and exegol (format: --volume {SyntaxFormat.volume})")
+                              help=f"Share a new volume between host and exegol (format: --volume {SyntaxFormat.volume})",
+                              completer=DirectoriesCompleter())
         self.ports = Option("-p", "--port",
                             action="append",
                             default=[],
@@ -240,7 +241,8 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                               dest="devices",
                               default=[],
                               action="append",
-                              help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/)")
+                              help="Add host [default not bold]device(s)[/default not bold] at the container creation (example: -d /dev/ttyACM0 -d /dev/bus/usb/)",
+                              completer=FilesCompleter(directories=True))
 
         self.hosts_file = Option("--hosts-file",
                         dest="hosts_file",
@@ -277,12 +279,13 @@ class ContainerCreation(ContainerSelector, ImageSelector):
                           default=None,
                           action="store",
                           help="Setup an OpenVPN (.ovpn) or WireGuard (.conf) connection at the container creation (example: --vpn /home/user/vpn/client.ovpn)",
-                          completer=FilesCompleter(["ovpn"], directories=True))
+                          completer=FilesCompleter(["ovpn", "conf"], directories=True))
         self.vpn_auth = Option("--vpn-auth",
                                dest="vpn_auth",
                                default=None,
                                action="store",
-                               help="Enter the credentials with a file (first line: username, second line: password) to establish the OpenVPN connection automatically (example: --vpn-auth /home/user/vpn/auth.txt)")
+                               help="Enter the credentials with a file (first line: username, second line: password) to establish the OpenVPN connection automatically (example: --vpn-auth /home/user/vpn/auth.txt)",
+                               completer=FilesCompleter())
 
         groupArgs.append(GroupArg({"arg": self.vpn, "required": False},
                                   {"arg": self.vpn_auth, "required": False},

--- a/exegol/manager/ExegolController.py
+++ b/exegol/manager/ExegolController.py
@@ -20,6 +20,7 @@ if ConstantConfig.completion_mode:
 import asyncio
 import http
 import logging
+import sys
 
 try:
     import docker
@@ -67,9 +68,14 @@ class ExegolController:
         """Dynamically retrieve the main function corresponding to the action selected by the user
         and execute it on the main thread"""
         try:
+            if cls.__action.stdout_is_data:
+                # Keep stdout clean for the action's output, every log message goes to stderr
+                ExeLog.console.file = sys.stderr
             await ExegolManager.print_version()
-            DockerUtils()  # Init dockerutils
-            await ExegolManager.print_debug_banner()
+            if cls.__action.require_docker:
+                DockerUtils()  # Init dockerutils
+                # The debug banner needs the environment data loaded by DockerUtils
+                await ExegolManager.print_debug_banner()
             # Check for missing parameters
             missing_params = cls.__action.check_parameters()
             if len(missing_params) == 0:

--- a/exegol/manager/ExegolController.py
+++ b/exegol/manager/ExegolController.py
@@ -1,3 +1,22 @@
+# PYTHON_ARGCOMPLETE_OK
+from exegol.config.ConstantConfig import ConstantConfig
+
+if ConstantConfig.completion_mode:
+    def __run_completion() -> None:
+        """Shell completion fast-path.
+        Building the parser triggers argcomplete, which supplies the completion options and terminates the process itself.
+        None of the heavy dependencies imported below (docker, git, supabase, ...) are ever loaded in this mode."""
+        # ExegolParameters must be imported first to register every Command subclass on the parser
+        from exegol.console.cli.actions import ExegolParameters  # noqa: F401
+        from exegol.console.cli.ParametersManager import ParametersManager
+        from exegol.utils.ExeLog import logger
+        # A completer must never terminate the process, an exception can be caught and reported as "no option"
+        logger.setCriticalMethod("raise")
+        ParametersManager()
+
+
+    __run_completion()
+
 import asyncio
 import http
 import logging

--- a/exegol/manager/ExegolManager.py
+++ b/exegol/manager/ExegolManager.py
@@ -233,6 +233,22 @@ class ExegolManager:
             await licence_manager.activate_exegol(skip_prompt=True)
 
     @classmethod
+    async def completion(cls) -> None:
+        """Print the shell completion script of the exegol wrapper"""
+        import argcomplete
+        shell = ParametersManager().shell_type
+        if shell is None:
+            # Auto-detect the user's shell from its environment
+            shell = os.path.basename(os.environ.get("SHELL", ""))
+            if shell not in ("bash", "zsh", "fish", "tcsh"):
+                shell = "bash"
+            logger.info(f"No shell supplied, using the auto-detected shell: [green]{shell}[/green]")
+        logger.info(f"Add the following script to your shell configuration, "
+                    f"check [green]exegol completion -h[/green] for ready-to-use commands.")
+        # Using a raw print here: the rich console would wrap and colorize the shell script and corrupt it
+        print(argcomplete.shellcode(["exegol"], shell=shell, use_defaults=False))
+
+    @classmethod
     async def print_version(cls) -> None:
         """Show exegol version (and context configuration on debug mode)"""
 

--- a/exegol/model/CacheModels.py
+++ b/exegol/model/CacheModels.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Optional, Dict, Union, Sequence, cast
+from typing import Any, List, Optional, Dict, Union, Sequence, cast
 
 from exegol.config.ConstantConfig import ConstantConfig
 from exegol.utils.ExeLog import logger
@@ -75,6 +75,44 @@ class ImagesCacheModel:
         return str(self)
 
 
+class ContainerCacheModel:
+    """This model store every important information for container caching."""
+
+    def __init__(self, name: str):
+        self.name: str = name
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+class ContainersCacheModel:
+    """This model can store multiple container and the date of the last update"""
+
+    def __init__(self, data: Sequence[Union[ContainerCacheModel, Dict]], metadata: Optional[Dict] = None):
+        # An old default date will be used until data are provided
+        default_date: Optional[str] = "01/01/1990" if len(data) == 0 else None
+        # Create or load (meta)data
+        self.metadata: MetadataCacheModel = MetadataCacheModel(default_date) if metadata is None else MetadataCacheModel(**metadata)
+        self.data: List[ContainerCacheModel] = []
+        if len(data) > 0:
+            if type(data[0]) is dict:
+                for container in data:
+                    self.data.append(ContainerCacheModel(**cast(Dict, container)))
+            elif type(data[0]) is ContainerCacheModel:
+                self.data = cast(List[ContainerCacheModel], data)
+            else:
+                raise NotImplementedError
+
+    def __str__(self) -> str:
+        return f"{len(self.data)} containers ({self.metadata.last_check})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
 class WrapperCacheModel:
     """Caching wrapper update information (last version / last update)"""
 
@@ -102,8 +140,13 @@ class CacheDB:
     def __init__(self) -> None:
         self.wrapper: WrapperCacheModel = WrapperCacheModel()
         self.images: ImagesCacheModel = ImagesCacheModel([])
+        self.containers: ContainersCacheModel = ContainersCacheModel([])
 
-    def load(self, wrapper: Dict, images: Dict) -> None:
-        """Load the CacheDB data from a raw Dict object"""
+    def load(self, wrapper: Dict, images: Dict, containers: Optional[Dict] = None, **kwargs: Any) -> None:
+        """Load the CacheDB data from a raw Dict object.
+        Every section added after the first version of the cache must have a default value
+        to stay compatible with cache files created by an older wrapper.
+        Unknown sections (i.e. written by a newer wrapper) are ignored."""
         self.wrapper = WrapperCacheModel(**wrapper)
         self.images = ImagesCacheModel(**images)
+        self.containers = ContainersCacheModel([]) if containers is None else ContainersCacheModel(**containers)

--- a/exegol/model/ExegolContainer.py
+++ b/exegol/model/ExegolContainer.py
@@ -13,6 +13,7 @@ from typing import Optional, Dict, Sequence, Tuple, Union, List
 from docker.errors import NotFound, ImageNotFound, APIError
 from docker.models.containers import Container
 
+from exegol.config.DataCache import DataCache
 from exegol.config.EnvInfo import EnvInfo
 from exegol.console.ExegolPrompt import ExegolRich
 from exegol.console.ExegolStatus import ExegolStatus
@@ -329,6 +330,7 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
             logger.success(f"Container {self.name} successfully removed.")
         except NotFound:
             logger.error(f"The container {self.name} has already been removed (probably created as a temporary container).")
+        DataCache().remove_container_cache(self.name)
         if not container_only:
             # Must be imported locally to avoid circular importation
             from exegol.utils.DockerUtils import DockerUtils
@@ -588,6 +590,9 @@ class ExegolContainer(ExegolContainerTemplate, SelectableInterface):
             logger.debug(f"Renaming container {self.getContainerName()} as {new_name}")
             try:
                 self.__container.rename(new_name)
+                # Reflect the rename on the container names used by the CLI autocompletion
+                DataCache().remove_container_cache(self.name)
+                DataCache().add_container_cache(new_name.removeprefix("exegol-"))
                 logger.success(f"Your previous container [orange3]{self.name}[/orange3] has been renamed to [green]{new_name[7:]}[/green] as a backup. You will need to delete it manually when it is no longer needed.")
                 return
             except APIError as e:

--- a/exegol/utils/DockerUtils.py
+++ b/exegol/utils/DockerUtils.py
@@ -101,6 +101,8 @@ class DockerUtils(metaclass=MetaSingleton):
                 return  # type: ignore
             for container in docker_containers:
                 self.__containers.append(ExegolContainer(container))
+            # Refresh the container names used by the CLI autocompletion
+            DataCache().update_container_cache([c.name for c in self.__containers])
         return self.__containers
 
     def createContainer(self, model: ExegolContainerTemplate, temporary: bool = False) -> ExegolContainer:
@@ -197,6 +199,9 @@ class DockerUtils(metaclass=MetaSingleton):
         else:
             logger.critical("Unknown error while creating exegol container. Exiting.")
             raise RuntimeError
+        if not temporary:
+            # Temporary containers are auto-removed by docker without any callback, they must never be cached
+            DataCache().add_container_cache(model.name)
         return ExegolContainer(container, model)
 
     def getContainer(self, tag: str) -> ExegolContainer:
@@ -239,6 +244,8 @@ class DockerUtils(metaclass=MetaSingleton):
             logger.debug(err)
             logger.critical(err.explanation)
             raise RuntimeError
+        # The name must be resolved before the removal, only the id is supplied to this method
+        removed_name = c.name.removeprefix("exegol-")
         try:
             c.reload()
             if c.status in ("running", "paused"):
@@ -248,6 +255,7 @@ class DockerUtils(metaclass=MetaSingleton):
             logger.debug(err)
             logger.critical(err.explanation)
             raise RuntimeError
+        DataCache().remove_container_cache(removed_name)
         return True
 
     def isContainerExist(self, container_id: str) -> Optional[str]:


### PR DESCRIPTION
# Description

Tab completion was effectively unusable. Every `<TAB>` spawned a fresh interpreter that imported the entire CLI stack: docker, git, supabase, postgrest, httpx, pydantic, cryptography, jwt, requests, before `argcomplete.autocomplete()` was even reached, and the container completer then did a full Docker daemon handshake plus a `containers.list()`, building a complete `ContainerConfig` per container. On top of that, nothing ever registered the completion with the user's shell, so most users never saw it work at all.

Measured on a real host, `dev` → this branch: **1015 ms → 270 ms per Tab (3.8x)**. The completion path drops from **52 exegol modules + 17 heavy third-party packages** to **19 modules + 0**: docker, git, supabase, postgrest, httpx, pydantic, cryptography, jwt, requests, urllib3 and tzlocal are no longer imported at all when completing.

Four changes, one per commit:

1. **Container names are cached on disk** (`Cache Exegol container names on disk`) in the existing `~/.exegol/.datacache`, alongside the image cache and following the same model/accessor pattern. Refreshed by `listContainers()` and kept converged by hooks on create / remove / rename: `createContainer` matters in particular, because `exegol start <newname>` never calls `listContainers()`.

2. **The completer reads only that cache** (`Read container names from cache for CLI completion`), never the daemon. This mirrors what `ImageCompleter` already did.

3. **The full CLI stack is skipped in completion mode** (`Skip the full CLI stack during shell completion`). When `_ARGCOMPLETE` is set, `ExegolController` builds the parser immediately and argcomplete terminates the process before the heavy imports below it. Three chains were deferred to keep parser construction itself light: `ExegolParameters`→`ExegolManager`, `ExegolCompleter`→`DockerUtils`/`UpdateManager`, and `UserConfig`→`SessionHandler`.

4. **`exegol completion [bash|zsh|fish|tcsh|powershell]`** (`Add the completion action and fix argument completers`) generates the script in-process via `argcomplete.shellcode()`. `PYTHON_ARGCOMPLETE_OK` is also added to `ExegolController.py`, the module the `pyproject.toml` console script actually resolves to. The existing marker in `exegol.py` never helped the installed binary, only `python3 exegol.py`.

Two bugs fixed along the way:

- **Completers could kill completion outright.** `DockerUtils` failures reach `logger.critical()`, which calls `exit(1)`: *inside the completer*. Since `SystemExit` derives from `BaseException`, no `except Exception` caught it, so a stopped or permission-denied Docker daemon silently killed the completion process. Completion mode now sets `setCriticalMethod("raise")` and every completer returns no options rather than raising.
- **Three completers mutated the list they were iterating** (`for obj in data: ... data.remove(obj)`), which skips elements and returns wrong suggestions.

# Related issues

fixes #290

The profiling in that issue named `ExegolController`, `ExegolManager`, `UserConfig`, `SessionHandler` and `DockerUtils` as the hot spots: all of them are addressed directly. @lap1nou's suggestion there of deferring imports until after `argcomplete.autocomplete()` is essentially the approach taken, adapted to the fact that building the parser is itself what pulls in the heavy modules here.

# Point of attention

- **AI assistance disclosure.** This contribution was developed with the help of Claude Code (Claude Opus 5) for the investigation, implementation and testing, under my direction and review. I'm flagging it explicitly given the IP terms in the contribution guide, please review accordingly, and tell me if you'd rather contributions not be prepared this way.

- **`UserConfig` in completion mode.** `SessionHandler()` is *called* during `UserConfig._process_data`, not merely imported, so deferring the import alone was not enough. The two licensed-feature lookups are gated behind `ConstantConfig.completion_mode`, defaulting `network_fallback_mode` to `docker` and `custom_images` to `[]`. Neither value is read on the completion path (`ContainerConfig.py:39`, `DockerUtils.py:456,458`, `ExegolImage.py:805`), but it is a process-wide mode flag and I'd welcome a second opinion on it.

- **Cache format compatibility.** `CacheDB.load()` gained `containers: Optional[Dict] = None` plus a `**kwargs` catch-all, so existing 2-key `.datacache` files load unchanged and a future added key won't break this version. The reverse is not true: a 3-key file read by an *older* wrapper raises `TypeError` on its fixed 2-argument signature. It is recoverable by deleting `.datacache`, but worth knowing for anyone downgrading.

- **`-o default` was removed** from the generated script, so "no suggestions" no longer falls back to dumping filenames. To compensate, the arguments that genuinely want paths declare completers: `-V/--volume`, `-d/--device`, `--vpn-auth`, `--build-log`, `--build-path`. `--vpn` also now offers `.conf`, which its help text already advertised for WireGuard.

- **The cache is advisory only**: used to suggest names, never for correctness. An out-of-band `docker rm` leaves it briefly stale until the next `listContainers()`. Temporary (`--tmp`) containers are deliberately never cached, since Docker auto-removes them with no callback to the wrapper.

- **The `.gitignore` commit is separable**: drop `Add Claude Code files to .gitignore` if you'd rather not carry AI-tool entries.

- **Residual ~150-250 ms** is `rich` + `yaml` + `ifaddr` at import time. Going below that means decoupling `ExeLog` from `rich`, which felt out of scope here.

- No version bump, no `spawn.sh` change, no dependency changes (`argcomplete` was already a dependency), so `requirements.txt` and `pyproject.toml` stay in sync as-is.

# Verification

Each of the 5 commits passes `mypy ./exegol/ --ignore-missing-imports --check-untyped-defs` independently, and the final state is clean across the CI matrix (3.10-3.14 x win32/linux/darwin).

Completion can be driven without a shell setup:

```bash
_ARGCOMPLETE=1 _ARGCOMPLETE_IFS=$'\n' _ARGCOMPLETE_SHELL=bash \
  COMP_LINE='exegol info ' COMP_POINT=12 exegol 8>&1 9>&2 1>/dev/null
```

Also verified end to end: real bash and zsh with the generated script installed; the cache being populated by `exegol info` from a live daemon and picked up on the next Tab; container completion still working with the **Docker daemon stopped**; unreadable and corrupt `.datacache` both degrading to "no suggestions" with exit 0 instead of a traceback; and an old 2-key cache file still loading and upgrading in place.
